### PR TITLE
tc-build: Add '-B' parameter to change build folder

### DIFF
--- a/build-binutils.py
+++ b/build-binutils.py
@@ -50,6 +50,17 @@ def parse_parameters(root):
     :return: A 'Namespace' object with all the options parsed from supplied parameters
     """
     parser = argparse.ArgumentParser()
+    parser.add_argument("-B",
+                        "--build-folder",
+                        help="""
+                        By default, the script will create a "build" folder in the same folder as this script
+                        then a "binutils" folder within that one and build the files there. If you would like
+                        that done somewhere else, pass it to this parameter. This can either be an absolute
+                        or relative path.
+                        """,
+                        type=str,
+                        default=os.path.join(root.as_posix(), "build",
+                                             "binutils"))
     parser.add_argument("-I",
                         "--install-folder",
                         help="""
@@ -204,6 +215,10 @@ def main():
 
     args = parse_parameters(root)
 
+    build_folder = pathlib.Path(args.build_folder)
+    if not build_folder.is_absolute():
+        build_folder = root.joinpath(build_folder)
+
     install_folder = pathlib.Path(args.install_folder)
     if not install_folder.is_absolute():
         install_folder = root.joinpath(install_folder)
@@ -214,8 +229,7 @@ def main():
 
     utils.download_binutils(root)
 
-    build_targets(root.joinpath("build", "binutils"), install_folder, root,
-                  create_targets(targets))
+    build_targets(build_folder, install_folder, root, create_targets(targets))
 
 
 if __name__ == '__main__':

--- a/build-binutils.py
+++ b/build-binutils.py
@@ -53,7 +53,7 @@ def parse_parameters(root):
     parser.add_argument("-B",
                         "--build-folder",
                         help="""
-                        By default, the script will create a "build" folder in the same folder as this script
+                        By default, the script will create a "build" folder in the same folder as this script,
                         then a "binutils" folder within that one and build the files there. If you would like
                         that done somewhere else, pass it to this parameter. This can either be an absolute
                         or relative path.

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -60,7 +60,7 @@ def parse_parameters(root_folder):
     parser.add_argument("-B",
                         "--build-folder",
                         help=textwrap.dedent("""\
-                        By default, the script will create a "build" folder in the same folder as this script
+                        By default, the script will create a "build" folder in the same folder as this script,
                         then an "llvm" folder within that one and build the files there. If you would like
                         that done somewhere else, pass it to this parameter. This can either be an absolute
                         or relative path.

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -57,6 +57,18 @@ def parse_parameters(root_folder):
                         """),
                         type=str,
                         default="master")
+    parser.add_argument("-B",
+                        "--build-folder",
+                        help=textwrap.dedent("""\
+                        By default, the script will create a "build" folder in the same folder as this script
+                        then an "llvm" folder within that one and build the files there. If you would like
+                        that done somewhere else, pass it to this parameter. This can either be an absolute
+                        or relative path.
+
+                        """),
+                        type=str,
+                        default=os.path.join(root_folder.as_posix(), "build",
+                                             "llvm"))
     parser.add_argument("-d",
                         "--debug",
                         help=textwrap.dedent("""\
@@ -597,10 +609,13 @@ def do_multistage_build(args, dirs, env_vars):
 
 def main():
     root_folder = pathlib.Path(__file__).resolve().parent
-    build_folder = root_folder.joinpath("build", "llvm")
-    stage1_folder = build_folder.joinpath("stage1")
 
     args = parse_parameters(root_folder)
+
+    build_folder = pathlib.Path(args.build_folder)
+    if not build_folder.is_absolute():
+        build_folder = root_folder.joinpath(build_folder)
+    stage1_folder = build_folder.joinpath("stage1")
 
     install_folder = pathlib.Path(args.install_folder)
     if not install_folder.is_absolute():


### PR DESCRIPTION
Some people might want to have their build folder elsewhere (like a
tmpfs mount) so add a parameter like the install folder one.