### PR TITLE
build-llvm.py: Enable LLVM_BUILD_LLVM_DYLIB

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -479,6 +479,10 @@ def stage_specific_cmake_defines(args, dirs, stage):
             defines['LLVM_ENABLE_WARNINGS'] = 'OFF'
             defines['LLVM_INCLUDE_TESTS'] = 'OFF'
 
+        # We need to build libLLVM.so to enable plugin support after
+        # https://github.com/llvm/llvm-project/commit/b7804ef3a746cd6c2c95c81eb19a81fb9df34cc6
+        defines['LLVM_BUILD_LLVM_DYLIB'] = 'ON'
+
         # Where the toolchain should be installed
         defines['CMAKE_INSTALL_PREFIX'] = dirs.install_folder.as_posix()
 


### PR DESCRIPTION
Without this, LLVM_ENABLE_PLUGINS does not get enabled after
https://github.com/llvm/llvm-project/commit/b7804ef3a746cd6c2c95c81eb19a81fb9df34cc6, which breaks LTO:

aarch64-linux-gnu-ld.gold: fatal error: LLVM gold plugin has failed to
create LTO module: Unknown attribute kind (60) (Producer: 'LLVM9.0.0svn'
Reader: 'LLVM 8.0.0')

I am not sure if this should be reported upstream or not since it seems like this is expected behavior now.