### PR TITLE
build-llvm.py: Fix UnboundLocalError in do_multistage_build

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -680,7 +680,7 @@ def do_multistage_build(args, dirs, env_vars):
             stages += [3]
         install_folder = dirs.install_folder
     else:
-        install_folder = dirs.build_folder.joinpath("stage%d" % stage)
+        install_folder = dirs.build_folder.joinpath("stage%d" % stages[0])
 
     for stage in stages:
         dirs.build_folder.joinpath("stage%d" % stage).mkdir(parents=True,


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "./build-llvm.py", line 719, in <module>
    main()
  File "./build-llvm.py", line 715, in main
    do_multistage_build(args, dirs, env_vars)
  File "./build-llvm.py", line 683, in do_multistage_build
    install_folder = dirs.build_folder.joinpath("stage%d" % stage)
UnboundLocalError: local variable 'stage' referenced before assignment
```