### PR TITLE
build-llvm.py: Don't use ccache past stage one

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -387,10 +387,6 @@ def base_cmake_defines(dirs):
     }
     # yapf: enable
 
-    # Use ccache if it is available for faster incremental builds
-    if shutil.which("ccache") is not None:
-        defines['LLVM_CCACHE_BUILD'] = 'ON'
-
     return defines
 
 
@@ -509,6 +505,11 @@ def stage_specific_cmake_defines(args, dirs, stage):
     :return: A set of defines
     """
     defines = {}
+
+    # Use ccache for the stage 1 build as it will usually be done with a consistent
+    # compiler and won't need a full rebuild very often
+    if stage == 1 and shutil.which("ccache") is not None:
+        defines['LLVM_CCACHE_BUILD'] = 'ON'
 
     if stage == 1 and not args.stage1_only:
         # Based on clang/cmake/caches/Apple-stage1.cmake


### PR DESCRIPTION
We gain pretty much nothing from ccache after the first stage because we
are using a fresh compiler, unlike stage one, which uses the host
compiler that does not change very often.

A simple test of this:

1. Apply https://gist.github.com/80bb34c45687ba2e5889af64fd5a5b89 to
   build-llvm.py (zero out ccache and print stats between stages).

2. $ ccache -Cz

3. $ ./build-llvm.py

   Stage one cache hit rate: 0.00%
   Stage two cache hit rate: 0.00%

4. $ git -C llvm-project checkout HEAD~50

5. $ ./build-llvm.py --no-pull

   Stage one cache hit rate: 44.51%
   Stage two cache hit rate: 0.00%

The primary motivation for this change is avoiding unnecessarily filling
the user's cache; each compiler can add anywhere from 200-300MB worth of
files to the cache, which will most likely not get used. Another
possible side effect could be some slight speed up from not testing the
cache, missing, then adding the file to the cache.