### PR TITLE
kernel/build.sh: Do not supply host variables

### DIFF
--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -75,7 +75,7 @@ done
 
 # SC2191: The = here is literal. To assign by index, use ( [index]=value ) with no spaces. To keep as literal, quote it.
 # shellcheck disable=SC2191
-MAKE=( make -j"$(nproc)" CC=clang HOSTCC=clang HOSTLD=ld.lld O=out )
+MAKE=( make -j"$(nproc)" CC=clang O=out )
 
 for TARGET in "${TARGETS[@]}"; do
     case ${TARGET} in


### PR DESCRIPTION
Some users may only target cross targets like ARM and AArch64, meaning
we cannot generate X86 code on an x86_64 host:

```
  HOSTCC  scripts/basic/fixdep
  GEN     Makefile
error: unable to create target: 'No available targets are compatible with triple "x86_64-unknown-linux-gnu"'
1 error generated.
make[3]: *** [scripts/Makefile.host:92: scripts/basic/fixdep] Error 1
```

Just remove the `HOST{CC,LD}` variables so that we don't cause a build
error, the host tools are a minor part of the build process so we don't
lose out on any PGO coverage this way.

Reported-by: @0ctobot