### PR TITLE
build-llvm.py: Add an option to set the vendor string

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -78,7 +78,7 @@ def parse_parameters(root_folder):
 
                         """),
                         type=str,
-                        default="")
+                        default="ClangBuiltLinux")
     parser.add_argument("-d",
                         "--debug",
                         help=textwrap.dedent("""\

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -74,7 +74,7 @@ def parse_parameters(root_folder):
                         "Android clang version..."). Useful when reverting or applying patches on top
                         of upstream clang to differentiate a toolchain built with this script from
                         upstream clang or to distinguish a toolchain built with this script from the
-                        system's clang. Defaults to empty.
+                        system's clang. Defaults to ClangBuiltLinux.
 
                         """),
                         type=str,

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -68,6 +68,17 @@ def parse_parameters(root_folder):
                         type=str,
                         default=os.path.join(root_folder.as_posix(), "build",
                                              "llvm"))
+    parser.add_argument("--clang-vendor",
+                        help=textwrap.dedent("""\
+                        Add this value to the clang version string (like "Apple clang version..." or
+                        "Android clang version..."). Useful when reverting or applying patches on top
+                        of upstream clang to differentiate a toolchain built with this script from
+                        upstream clang or to distinguish a toolchain built with this script from the
+                        system's clang. Defaults to empty.
+
+                        """),
+                        type=str,
+                        default="")
     parser.add_argument("-d",
                         "--debug",
                         help=textwrap.dedent("""\
@@ -574,6 +585,10 @@ def build_cmake_defines(args, dirs, env_vars, stage):
     if args.march_native:
         defines['CMAKE_C_FLAGS'] = '-march=native -mtune=native'
         defines['CMAKE_CXX_FLAGS'] = '-march=native -mtune=native'
+
+    # Add the vendor string if necessary
+    if args.clang_vendor:
+        defines['CLANG_VENDOR'] = args.clang_vendor
 
     return defines
 


### PR DESCRIPTION
Some users want this to be able to distinguish their builds from clang
upstream, either because of cherry-picks/reverts or to easily see if
their own build was what compiled their kernel or if it was the
system's.

cc @0ctobot @Wight554