### PR TITLE
github: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+*.py @MSF-Jarvis @nathanchance @nickdesaulniers @stephenhines
+*.sh @MSF-Jarvis @nathanchance @nickdesaulniers @stephenhines


### PR DESCRIPTION
Used by GitHub to automatically request review from concerned people on PRs.

https://help.github.com/en/articles/about-code-owners