### PR TITLE
kernel/build.sh: Improve handling of Linux source tarballs

### DIFF
--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -47,7 +47,7 @@ if [[ -n ${SRC_FOLDER} ]]; then
     cd "${SRC_FOLDER}" || exit 1
 else
     LINUX=linux-5.1
-    LINUX_TARBALL=${TC_BLD}/kernel/${LINUX}.tar.gz
+    LINUX_TARBALL=${TC_BLD}/kernel/${LINUX}.tar.xz
     LINUX_PATCH=${TC_BLD}/kernel/${LINUX}.patch
 
     # If we don't have the source tarball, download it
@@ -55,7 +55,7 @@ else
 
     # If there is a patch to apply, remove the folder so that we can patch it accurately (we cannot assume it has already been patched)
     [[ -f ${LINUX_PATCH} ]] && rm -rf ${LINUX}
-    [[ -d ${LINUX} ]] || { tar -xzf "${LINUX_TARBALL}" || exit ${?}; }
+    [[ -d ${LINUX} ]] || { tar -xf "${LINUX_TARBALL}" || exit ${?}; }
     cd ${LINUX} || exit 1
     [[ -f ${LINUX_PATCH} ]] && patch -p1 < "${LINUX_PATCH}"
 fi


### PR DESCRIPTION
Some little improvements in handling Linux source tarballs:

Save download band width by using *.tar.xz tarballs from <kernel.org>
(Linux v5.2: approx. 50MiB).

Simplify the decompression of tarballs as modern tar versions are
smart enough to detect the (de)compressor.

Further improvements (TBD):
Verify the sign file [2]  of the desired Linux source tarball.

Details see tc-build issue #26:
"Linux sources: Download XZ tarball, simplify decompressing and verify sign-file"

[1] https://github.com/ClangBuiltLinux/tc-build/issues/26
[2] https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/linux-5.2.tar.sign