### PR TITLE
Three miscellaneous improvements

### DIFF
--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -31,7 +31,7 @@ while (( ${#} )); do
     esac
     shift
 done
-[[ -z ${TARGETS} ]] && TARGETS=( "arm-linux-gnueabi" "aarch64-linux-gnu" "powerpc-linux-gnu" "powerpc64le-linux-gnu" "x86_64-linux-gnu" )
+[[ -z ${TARGETS[*]} ]] && TARGETS=( "arm-linux-gnueabi" "aarch64-linux-gnu" "powerpc-linux-gnu" "powerpc64le-linux-gnu" "x86_64-linux-gnu" )
 
 # Add the default install bin folder to PATH for binutils
 # Add the stage 2 bin folder to PATH for the instrumented clang
@@ -86,10 +86,10 @@ MAKE=( make -j"$(nproc)" CC=clang O=out )
 
 for TARGET in "${TARGETS[@]}"; do
     case ${TARGET} in
-        "arm-linux-gnueabi") time "${MAKE[@]}" ARCH=arm CROSS_COMPILE=${TARGET}- LD=ld.lld distclean defconfig zImage modules || exit ${?} ;;
-        "aarch64-linux-gnu") time "${MAKE[@]}" ARCH=arm64 CROSS_COMPILE=${TARGET}- LD=ld.lld distclean defconfig Image.gz modules || exit ${?} ;;
-        "powerpc-linux-gnu") time "${MAKE[@]}" ARCH=powerpc CROSS_COMPILE=${TARGET}- distclean ppc44x_defconfig zImage modules || exit ${?} ;;
-        "powerpc64le-linux-gnu") time "${MAKE[@]}" ARCH=powerpc CROSS_COMPILE=${TARGET}- distclean powernv_defconfig zImage.epapr modules || exit ${?} ;;
+        "arm-linux-gnueabi") time "${MAKE[@]}" ARCH=arm CROSS_COMPILE="${TARGET}-" LD=ld.lld distclean defconfig zImage modules || exit ${?} ;;
+        "aarch64-linux-gnu") time "${MAKE[@]}" ARCH=arm64 CROSS_COMPILE="${TARGET}-" LD=ld.lld distclean defconfig Image.gz modules || exit ${?} ;;
+        "powerpc-linux-gnu") time "${MAKE[@]}" ARCH=powerpc CROSS_COMPILE="${TARGET}-" distclean ppc44x_defconfig zImage modules || exit ${?} ;;
+        "powerpc64le-linux-gnu") time "${MAKE[@]}" ARCH=powerpc CROSS_COMPILE="${TARGET}-" distclean powernv_defconfig zImage.epapr modules || exit ${?} ;;
         "x86_64-linux-gnu") time "${MAKE[@]}" LD=ld.lld O=out distclean defconfig bzImage modules || exit ${?} ;;
     esac
 done

--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -7,6 +7,8 @@ TC_BLD=$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/.. && pwd)
 # Parse parameters
 while (( ${#} )); do
     case ${1} in
+        "--allyesconfig")
+            CONFIG_TARGET=allyesconfig ;;
         "-b"|"--build-folder")
             shift
             BUILD_FOLDER=${1} ;;
@@ -48,7 +50,7 @@ if [[ -n ${SRC_FOLDER} ]]; then
 else
     LINUX=linux-5.2
     LINUX_TARBALL=${TC_BLD}/kernel/${LINUX}.tar.xz
-    LINUX_PATCH=${TC_BLD}/kernel/${LINUX}.patch
+    LINUX_PATCH=${TC_BLD}/kernel/${LINUX}-${CONFIG_TARGET:=defconfig}.patch
 
     # If we don't have the source tarball, download and verify it
     if [[ ! -f ${LINUX_TARBALL} ]]; then
@@ -64,7 +66,7 @@ else
     [[ -f ${LINUX_PATCH} ]] && rm -rf ${LINUX}
     [[ -d ${LINUX} ]] || { tar -xf "${LINUX_TARBALL}" || exit ${?}; }
     cd ${LINUX} || exit 1
-    [[ -f ${LINUX_PATCH} ]] && patch -p1 < "${LINUX_PATCH}"
+    [[ -f ${LINUX_PATCH} ]] && { git apply "${LINUX_PATCH}" || exit ${?}; }
 fi
 
 # Check for all binutils and build them if necessary
@@ -86,10 +88,10 @@ MAKE=( make -j"$(nproc)" CC=clang O=out )
 
 for TARGET in "${TARGETS[@]}"; do
     case ${TARGET} in
-        "arm-linux-gnueabi") time "${MAKE[@]}" ARCH=arm CROSS_COMPILE="${TARGET}-" LD=ld.lld distclean defconfig zImage modules || exit ${?} ;;
-        "aarch64-linux-gnu") time "${MAKE[@]}" ARCH=arm64 CROSS_COMPILE="${TARGET}-" LD=ld.lld distclean defconfig Image.gz modules || exit ${?} ;;
+        "arm-linux-gnueabi") time "${MAKE[@]}" ARCH=arm CROSS_COMPILE="${TARGET}-" LD=ld.lld distclean "${CONFIG_TARGET}" zImage modules || exit ${?} ;;
+        "aarch64-linux-gnu") time "${MAKE[@]}" ARCH=arm64 CROSS_COMPILE="${TARGET}-" LD=ld.lld distclean "${CONFIG_TARGET}" Image.gz modules || exit ${?} ;;
         "powerpc-linux-gnu") time "${MAKE[@]}" ARCH=powerpc CROSS_COMPILE="${TARGET}-" distclean ppc44x_defconfig zImage modules || exit ${?} ;;
         "powerpc64le-linux-gnu") time "${MAKE[@]}" ARCH=powerpc CROSS_COMPILE="${TARGET}-" distclean powernv_defconfig zImage.epapr modules || exit ${?} ;;
-        "x86_64-linux-gnu") time "${MAKE[@]}" LD=ld.lld O=out distclean defconfig bzImage modules || exit ${?} ;;
+        "x86_64-linux-gnu") time "${MAKE[@]}" LD=ld.lld O=out distclean "${CONFIG_TARGET}" bzImage modules || exit ${?} ;;
     esac
 done

--- a/kernel/linux-5.2-allyesconfig.patch
+++ b/kernel/linux-5.2-allyesconfig.patch
@@ -1,0 +1,761 @@
+From f511aeabd58d25879aa222caf71bf5905927fc4f Mon Sep 17 00:00:00 2001
+From: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>
+Date: Thu, 30 May 2019 06:50:11 -0500
+Subject: [PATCH 1/4] ASoC: Intel: use common helpers to detect CPUs
+
+We have duplicated code in multiple locations (atom, machine drivers,
+SOF) to detect Baytrail, Cherrytrail and other SOCs. This is not very
+elegant, and introduces dependencies on CONFIG_X86 that prevent
+COMPILE_TEST from working.
+
+Add common helpers to provide same functionality in a cleaner
+way. This will also help support the DMI-based quirks being introduced
+to handle SOF/SST autodetection.
+
+Reviewed-by: Takashi Iwai <tiwai@suse.de>
+Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>
+Signed-off-by: Mark Brown <broonie@kernel.org>
+(am from https://git.kernel.org/broonie/sound/c/536cfd2f375d36f4316c0b93bb9e0eaf78e0ef6c)
+Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>
+---
+ sound/soc/intel/atom/sst/sst_acpi.c           |  65 +---------
+ sound/soc/intel/boards/bxt_da7219_max98357a.c |  11 +-
+ sound/soc/intel/boards/bytcht_es8316.c        |  12 +-
+ sound/soc/intel/boards/bytcr_rt5640.c         |  16 +--
+ sound/soc/intel/boards/bytcr_rt5651.c         |  17 +--
+ sound/soc/intel/boards/cht_bsw_rt5645.c       |  16 +--
+ sound/soc/intel/boards/sof_rt5682.c           |  11 +-
+ sound/soc/intel/common/soc-intel-quirks.h     | 115 ++++++++++++++++++
+ sound/soc/sof/sof-acpi-dev.c                  |  57 +--------
+ 9 files changed, 135 insertions(+), 185 deletions(-)
+ create mode 100644 sound/soc/intel/common/soc-intel-quirks.h
+
+diff --git a/sound/soc/intel/atom/sst/sst_acpi.c b/sound/soc/intel/atom/sst/sst_acpi.c
+index f1f4aadb6683..b728fb56ea4d 100644
+--- a/sound/soc/intel/atom/sst/sst_acpi.c
++++ b/sound/soc/intel/atom/sst/sst_acpi.c
+@@ -28,12 +28,11 @@
+ #include <acpi/platform/aclinux.h>
+ #include <acpi/actypes.h>
+ #include <acpi/acpi_bus.h>
+-#include <asm/cpu_device_id.h>
+-#include <asm/iosf_mbi.h>
+ #include <sound/soc-acpi.h>
+ #include <sound/soc-acpi-intel-match.h>
+ #include "../sst-mfld-platform.h"
+ #include "../../common/sst-dsp.h"
++#include "../../common/soc-intel-quirks.h"
+ #include "sst.h"
+ 
+ /* LPE viewpoint addresses */
+@@ -233,64 +232,6 @@ static int sst_platform_get_resources(struct intel_sst_drv *ctx)
+ 	return 0;
+ }
+ 
+-static int is_byt(void)
+-{
+-	bool status = false;
+-	static const struct x86_cpu_id cpu_ids[] = {
+-		{ X86_VENDOR_INTEL, 6, 55 }, /* Valleyview, Bay Trail */
+-		{}
+-	};
+-	if (x86_match_cpu(cpu_ids))
+-		status = true;
+-	return status;
+-}
+-
+-static bool is_byt_cr(struct platform_device *pdev)
+-{
+-	struct device *dev = &pdev->dev;
+-	int status = 0;
+-
+-	if (!is_byt())
+-		return false;
+-
+-	if (iosf_mbi_available()) {
+-		u32 bios_status;
+-		status = iosf_mbi_read(BT_MBI_UNIT_PMC, /* 0x04 PUNIT */
+-				       MBI_REG_READ, /* 0x10 */
+-				       0x006, /* BIOS_CONFIG */
+-				       &bios_status);
+-
+-		if (status) {
+-			dev_err(dev, "could not read PUNIT BIOS_CONFIG\n");
+-		} else {
+-			/* bits 26:27 mirror PMIC options */
+-			bios_status = (bios_status >> 26) & 3;
+-
+-			if (bios_status == 1 || bios_status == 3) {
+-				dev_info(dev, "Detected Baytrail-CR platform\n");
+-				return true;
+-			}
+-
+-			dev_info(dev, "BYT-CR not detected\n");
+-		}
+-	} else {
+-		dev_info(dev, "IOSF_MBI not available, no BYT-CR detection\n");
+-	}
+-
+-	if (platform_get_resource(pdev, IORESOURCE_IRQ, 5) == NULL) {
+-		/*
+-		 * Some devices detected as BYT-T have only a single IRQ listed,
+-		 * causing platform_get_irq with index 5 to return -ENXIO.
+-		 * The correct IRQ in this case is at index 0, as on BYT-CR.
+-		 */
+-		dev_info(dev, "Falling back to Baytrail-CR platform\n");
+-		return true;
+-	}
+-
+-	return false;
+-}
+-
+-
+ static int sst_acpi_probe(struct platform_device *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
+@@ -315,7 +256,7 @@ static int sst_acpi_probe(struct platform_device *pdev)
+ 		return -ENODEV;
+ 	}
+ 
+-	if (is_byt())
++	if (soc_intel_is_byt())
+ 		mach->pdata = &byt_rvp_platform_data;
+ 	else
+ 		mach->pdata = &chv_platform_data;
+@@ -333,7 +274,7 @@ static int sst_acpi_probe(struct platform_device *pdev)
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	if (is_byt_cr(pdev)) {
++	if (soc_intel_is_byt_cr(pdev)) {
+ 		/* override resource info */
+ 		byt_rvp_platform_data.res_info = &bytcr_res_info;
+ 	}
+diff --git a/sound/soc/intel/boards/bxt_da7219_max98357a.c b/sound/soc/intel/boards/bxt_da7219_max98357a.c
+index 1c4f4c124b00..3f91bc457474 100644
+--- a/sound/soc/intel/boards/bxt_da7219_max98357a.c
++++ b/sound/soc/intel/boards/bxt_da7219_max98357a.c
+@@ -8,7 +8,6 @@
+  *   Intel Skylake I2S Machine driver
+  */
+ 
+-#include <asm/cpu_device_id.h>
+ #include <linux/input.h>
+ #include <linux/module.h>
+ #include <linux/platform_device.h>
+@@ -21,6 +20,7 @@
+ #include "../../codecs/hdac_hdmi.h"
+ #include "../../codecs/da7219.h"
+ #include "../../codecs/da7219-aad.h"
++#include "../common/soc-intel-quirks.h"
+ 
+ #define BXT_DIALOG_CODEC_DAI	"da7219-hifi"
+ #define BXT_MAXIM_CODEC_DAI	"HiFi"
+@@ -560,11 +560,6 @@ static struct snd_soc_dai_link broxton_dais[] = {
+ 	},
+ };
+ 
+-static const struct x86_cpu_id glk_ids[] = {
+-	{ X86_VENDOR_INTEL, 6, 0x7A }, /* Geminilake CPU_ID */
+-	{}
+-};
+-
+ #define NAME_SIZE	32
+ static int bxt_card_late_probe(struct snd_soc_card *card)
+ {
+@@ -574,7 +569,7 @@ static int bxt_card_late_probe(struct snd_soc_card *card)
+ 	int err, i = 0;
+ 	char jack_name[NAME_SIZE];
+ 
+-	if (x86_match_cpu(glk_ids))
++	if (soc_intel_is_glk())
+ 		snd_soc_dapm_add_routes(&card->dapm, gemini_map,
+ 					ARRAY_SIZE(gemini_map));
+ 	else
+@@ -637,7 +632,7 @@ static int broxton_audio_probe(struct platform_device *pdev)
+ 
+ 	broxton_audio_card.dev = &pdev->dev;
+ 	snd_soc_card_set_drvdata(&broxton_audio_card, ctx);
+-	if (x86_match_cpu(glk_ids)) {
++	if (soc_intel_is_glk()) {
+ 		unsigned int i;
+ 
+ 		broxton_audio_card.name = "glkda7219max";
+diff --git a/sound/soc/intel/boards/bytcht_es8316.c b/sound/soc/intel/boards/bytcht_es8316.c
+index 2fe1ce879123..e7fc4f1707e6 100644
+--- a/sound/soc/intel/boards/bytcht_es8316.c
++++ b/sound/soc/intel/boards/bytcht_es8316.c
+@@ -22,8 +22,6 @@
+ #include <linux/module.h>
+ #include <linux/platform_device.h>
+ #include <linux/slab.h>
+-#include <asm/cpu_device_id.h>
+-#include <asm/intel-family.h>
+ #include <asm/platform_sst_audio.h>
+ #include <sound/jack.h>
+ #include <sound/pcm.h>
+@@ -32,6 +30,7 @@
+ #include <sound/soc-acpi.h>
+ #include "../atom/sst-atom-controls.h"
+ #include "../common/sst-dsp.h"
++#include "../common/soc-intel-quirks.h"
+ 
+ /* jd-inv + terminating entry */
+ #define MAX_NO_PROPS 2
+@@ -422,11 +421,6 @@ static struct snd_soc_card byt_cht_es8316_card = {
+ 	.resume_post = byt_cht_es8316_resume,
+ };
+ 
+-static const struct x86_cpu_id baytrail_cpu_ids[] = {
+-	{ X86_VENDOR_INTEL, 6, INTEL_FAM6_ATOM_SILVERMONT }, /* Valleyview */
+-	{}
+-};
+-
+ static const struct acpi_gpio_params first_gpio = { 0, 0, false };
+ 
+ static const struct acpi_gpio_mapping byt_cht_es8316_gpios[] = {
+@@ -499,8 +493,8 @@ static int snd_byt_cht_es8316_mc_probe(struct platform_device *pdev)
+ 	dmi_id = dmi_first_match(byt_cht_es8316_quirk_table);
+ 	if (dmi_id) {
+ 		quirk = (unsigned long)dmi_id->driver_data;
+-	} else if (x86_match_cpu(baytrail_cpu_ids) &&
+-	    mach->mach_params.acpi_ipc_irq_index == 0) {
++	} else if (soc_intel_is_byt() &&
++		   mach->mach_params.acpi_ipc_irq_index == 0) {
+ 		/* On BYTCR default to SSP0, internal-mic-in2-map, mono-spk */
+ 		quirk = BYT_CHT_ES8316_SSP0 | BYT_CHT_ES8316_INTMIC_IN2_MAP |
+ 			BYT_CHT_ES8316_MONO_SPEAKER;
+diff --git a/sound/soc/intel/boards/bytcr_rt5640.c b/sound/soc/intel/boards/bytcr_rt5640.c
+index b906cfd5f97d..1e100ae4ba8e 100644
+--- a/sound/soc/intel/boards/bytcr_rt5640.c
++++ b/sound/soc/intel/boards/bytcr_rt5640.c
+@@ -20,7 +20,6 @@
+ #include <linux/dmi.h>
+ #include <linux/input.h>
+ #include <linux/slab.h>
+-#include <asm/cpu_device_id.h>
+ #include <sound/pcm.h>
+ #include <sound/pcm_params.h>
+ #include <sound/soc.h>
+@@ -30,6 +29,7 @@
+ #include "../../codecs/rt5640.h"
+ #include "../atom/sst-atom-controls.h"
+ #include "../common/sst-dsp.h"
++#include "../common/soc-intel-quirks.h"
+ 
+ enum {
+ 	BYT_RT5640_DMIC1_MAP,
+@@ -1122,18 +1122,6 @@ static struct snd_soc_card byt_rt5640_card = {
+ 	.resume_post = byt_rt5640_resume,
+ };
+ 
+-static bool is_valleyview(void)
+-{
+-	static const struct x86_cpu_id cpu_ids[] = {
+-		{ X86_VENDOR_INTEL, 6, 55 }, /* Valleyview, Bay Trail */
+-		{}
+-	};
+-
+-	if (!x86_match_cpu(cpu_ids))
+-		return false;
+-	return true;
+-}
+-
+ struct acpi_chan_package {   /* ACPICA seems to require 64 bit integers */
+ 	u64 aif_value;       /* 1: AIF1, 2: AIF2 */
+ 	u64 mclock_value;    /* usually 25MHz (0x17d7940), ignored */
+@@ -1182,7 +1170,7 @@ static int snd_byt_rt5640_mc_probe(struct platform_device *pdev)
+ 	 * swap SSP0 if bytcr is detected
+ 	 * (will be overridden if DMI quirk is detected)
+ 	 */
+-	if (is_valleyview()) {
++	if (soc_intel_is_byt()) {
+ 		if (mach->mach_params.acpi_ipc_irq_index == 0)
+ 			is_bytcr = true;
+ 	}
+diff --git a/sound/soc/intel/boards/bytcr_rt5651.c b/sound/soc/intel/boards/bytcr_rt5651.c
+index c7b627137a62..6db773e03591 100644
+--- a/sound/soc/intel/boards/bytcr_rt5651.c
++++ b/sound/soc/intel/boards/bytcr_rt5651.c
+@@ -22,8 +22,6 @@
+ #include <linux/gpio/consumer.h>
+ #include <linux/gpio/machine.h>
+ #include <linux/slab.h>
+-#include <asm/cpu_device_id.h>
+-#include <asm/intel-family.h>
+ #include <sound/pcm.h>
+ #include <sound/pcm_params.h>
+ #include <sound/soc.h>
+@@ -31,6 +29,7 @@
+ #include <sound/soc-acpi.h>
+ #include "../../codecs/rt5651.h"
+ #include "../atom/sst-atom-controls.h"
++#include "../common/soc-intel-quirks.h"
+ 
+ enum {
+ 	BYT_RT5651_DMIC_MAP,
+@@ -844,16 +843,6 @@ static struct snd_soc_card byt_rt5651_card = {
+ 	.resume_post = byt_rt5651_resume,
+ };
+ 
+-static const struct x86_cpu_id baytrail_cpu_ids[] = {
+-	{ X86_VENDOR_INTEL, 6, INTEL_FAM6_ATOM_SILVERMONT }, /* Valleyview */
+-	{}
+-};
+-
+-static const struct x86_cpu_id cherrytrail_cpu_ids[] = {
+-	{ X86_VENDOR_INTEL, 6, INTEL_FAM6_ATOM_AIRMONT },     /* Braswell */
+-	{}
+-};
+-
+ static const struct acpi_gpio_params ext_amp_enable_gpios = { 0, 0, false };
+ 
+ static const struct acpi_gpio_mapping cht_rt5651_gpios[] = {
+@@ -924,7 +913,7 @@ static int snd_byt_rt5651_mc_probe(struct platform_device *pdev)
+ 	 * swap SSP0 if bytcr is detected
+ 	 * (will be overridden if DMI quirk is detected)
+ 	 */
+-	if (x86_match_cpu(baytrail_cpu_ids)) {
++	if (soc_intel_is_byt()) {
+ 		if (mach->mach_params.acpi_ipc_irq_index == 0)
+ 			is_bytcr = true;
+ 	}
+@@ -993,7 +982,7 @@ static int snd_byt_rt5651_mc_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	/* Cherry Trail devices use an external amplifier enable gpio */
+-	if (x86_match_cpu(cherrytrail_cpu_ids) && !byt_rt5651_gpios)
++	if (soc_intel_is_cht() && !byt_rt5651_gpios)
+ 		byt_rt5651_gpios = cht_rt5651_gpios;
+ 
+ 	if (byt_rt5651_gpios) {
+diff --git a/sound/soc/intel/boards/cht_bsw_rt5645.c b/sound/soc/intel/boards/cht_bsw_rt5645.c
+index 2c07ec8b42ae..f331cdab9c08 100644
+--- a/sound/soc/intel/boards/cht_bsw_rt5645.c
++++ b/sound/soc/intel/boards/cht_bsw_rt5645.c
+@@ -18,7 +18,6 @@
+ #include <linux/clk.h>
+ #include <linux/dmi.h>
+ #include <linux/slab.h>
+-#include <asm/cpu_device_id.h>
+ #include <sound/pcm.h>
+ #include <sound/pcm_params.h>
+ #include <sound/soc.h>
+@@ -26,6 +25,7 @@
+ #include <sound/soc-acpi.h>
+ #include "../../codecs/rt5645.h"
+ #include "../atom/sst-atom-controls.h"
++#include "../common/soc-intel-quirks.h"
+ 
+ #define CHT_PLAT_CLK_3_HZ	19200000
+ #define CHT_CODEC_DAI1	"rt5645-aif1"
+@@ -501,18 +501,6 @@ static char cht_rt5645_codec_name[SND_ACPI_I2C_ID_LEN];
+ static char cht_rt5645_codec_aif_name[12]; /*  = "rt5645-aif[1|2]" */
+ static char cht_rt5645_cpu_dai_name[10]; /*  = "ssp[0|2]-port" */
+ 
+-static bool is_valleyview(void)
+-{
+-	static const struct x86_cpu_id cpu_ids[] = {
+-		{ X86_VENDOR_INTEL, 6, 55 }, /* Valleyview, Bay Trail */
+-		{}
+-	};
+-
+-	if (!x86_match_cpu(cpu_ids))
+-		return false;
+-	return true;
+-}
+-
+ struct acpi_chan_package {   /* ACPICA seems to require 64 bit integers */
+ 	u64 aif_value;       /* 1: AIF1, 2: AIF2 */
+ 	u64 mclock_value;    /* usually 25MHz (0x17d7940), ignored */
+@@ -577,7 +565,7 @@ static int snd_cht_mc_probe(struct platform_device *pdev)
+ 	 * swap SSP0 if bytcr is detected
+ 	 * (will be overridden if DMI quirk is detected)
+ 	 */
+-	if (is_valleyview()) {
++	if (soc_intel_is_byt()) {
+ 		if (mach->mach_params.acpi_ipc_irq_index == 0)
+ 			is_bytcr = true;
+ 	}
+diff --git a/sound/soc/intel/boards/sof_rt5682.c b/sound/soc/intel/boards/sof_rt5682.c
+index 3343dbcd506f..e362b71c0419 100644
+--- a/sound/soc/intel/boards/sof_rt5682.c
++++ b/sound/soc/intel/boards/sof_rt5682.c
+@@ -10,8 +10,6 @@
+ #include <linux/module.h>
+ #include <linux/platform_device.h>
+ #include <linux/dmi.h>
+-#include <asm/cpu_device_id.h>
+-#include <asm/intel-family.h>
+ #include <sound/core.h>
+ #include <sound/jack.h>
+ #include <sound/pcm.h>
+@@ -21,6 +19,7 @@
+ #include <sound/soc-acpi.h>
+ #include "../../codecs/rt5682.h"
+ #include "../../codecs/hdac_hdmi.h"
++#include "../common/soc-intel-quirks.h"
+ 
+ #define NAME_SIZE 32
+ 
+@@ -304,12 +303,6 @@ static struct snd_soc_card sof_audio_card_rt5682 = {
+ 	.late_probe = sof_card_late_probe,
+ };
+ 
+-static const struct x86_cpu_id legacy_cpi_ids[] = {
+-	{ X86_VENDOR_INTEL, 6, INTEL_FAM6_ATOM_SILVERMONT }, /* Baytrail */
+-	{ X86_VENDOR_INTEL, 6, INTEL_FAM6_ATOM_AIRMONT }, /* Cherrytrail */
+-	{}
+-};
+-
+ static struct snd_soc_dai_link_component rt5682_component[] = {
+ 	{
+ 		.name = "i2c-10EC5682:00",
+@@ -498,7 +491,7 @@ static int sof_audio_probe(struct platform_device *pdev)
+ 	if (!ctx)
+ 		return -ENOMEM;
+ 
+-	if (x86_match_cpu(legacy_cpi_ids)) {
++	if (soc_intel_is_byt() || soc_intel_is_cht()) {
+ 		is_legacy_cpu = 1;
+ 		dmic_num = 0;
+ 		hdmi_num = 0;
+diff --git a/sound/soc/intel/common/soc-intel-quirks.h b/sound/soc/intel/common/soc-intel-quirks.h
+new file mode 100644
+index 000000000000..4718fd3cf636
+--- /dev/null
++++ b/sound/soc/intel/common/soc-intel-quirks.h
+@@ -0,0 +1,115 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * soc-intel-quirks.h - prototypes for quirk autodetection
++ *
++ * Copyright (c) 2019, Intel Corporation.
++ *
++ */
++
++#ifndef _SND_SOC_INTEL_QUIRKS_H
++#define _SND_SOC_INTEL_QUIRKS_H
++
++#if IS_ENABLED(CONFIG_X86)
++
++#include <asm/cpu_device_id.h>
++#include <asm/intel-family.h>
++#include <asm/iosf_mbi.h>
++
++#define ICPU(model)	{ X86_VENDOR_INTEL, 6, model, X86_FEATURE_ANY, }
++
++#define SOC_INTEL_IS_CPU(soc, type)				\
++static inline bool soc_intel_is_##soc(void)			\
++{								\
++	static const struct x86_cpu_id soc##_cpu_ids[] = {	\
++		ICPU(type),					\
++		{}						\
++	};							\
++	const struct x86_cpu_id *id;				\
++								\
++	id = x86_match_cpu(soc##_cpu_ids);			\
++	if (id)							\
++		return true;					\
++	return false;						\
++}
++
++SOC_INTEL_IS_CPU(byt, INTEL_FAM6_ATOM_SILVERMONT);
++SOC_INTEL_IS_CPU(cht, INTEL_FAM6_ATOM_AIRMONT);
++SOC_INTEL_IS_CPU(apl, INTEL_FAM6_ATOM_GOLDMONT);
++SOC_INTEL_IS_CPU(glk, INTEL_FAM6_ATOM_GOLDMONT_PLUS);
++
++static inline bool soc_intel_is_byt_cr(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++	int status = 0;
++
++	if (!soc_intel_is_byt())
++		return false;
++
++	if (iosf_mbi_available()) {
++		u32 bios_status;
++
++		status = iosf_mbi_read(BT_MBI_UNIT_PMC, /* 0x04 PUNIT */
++				       MBI_REG_READ, /* 0x10 */
++				       0x006, /* BIOS_CONFIG */
++				       &bios_status);
++
++		if (status) {
++			dev_err(dev, "could not read PUNIT BIOS_CONFIG\n");
++		} else {
++			/* bits 26:27 mirror PMIC options */
++			bios_status = (bios_status >> 26) & 3;
++
++			if (bios_status == 1 || bios_status == 3) {
++				dev_info(dev, "Detected Baytrail-CR platform\n");
++				return true;
++			}
++
++			dev_info(dev, "BYT-CR not detected\n");
++		}
++	} else {
++		dev_info(dev, "IOSF_MBI not available, no BYT-CR detection\n");
++	}
++
++	if (!platform_get_resource(pdev, IORESOURCE_IRQ, 5)) {
++		/*
++		 * Some devices detected as BYT-T have only a single IRQ listed,
++		 * causing platform_get_irq with index 5 to return -ENXIO.
++		 * The correct IRQ in this case is at index 0, as on BYT-CR.
++		 */
++		dev_info(dev, "Falling back to Baytrail-CR platform\n");
++		return true;
++	}
++
++	return false;
++}
++
++#else
++
++static inline bool soc_intel_is_byt_cr(struct platform_device *pdev)
++{
++	return false;
++}
++
++static inline bool soc_intel_is_byt(void)
++{
++	return false;
++}
++
++static inline bool soc_intel_is_cht(void)
++{
++	return false;
++}
++
++static inline bool soc_intel_is_apl(void)
++{
++	return false;
++}
++
++static inline bool soc_intel_is_glk(void)
++{
++	return false;
++}
++
++#endif
++
++ #endif /* _SND_SOC_INTEL_QUIRKS_H */
+diff --git a/sound/soc/sof/sof-acpi-dev.c b/sound/soc/sof/sof-acpi-dev.c
+index e9cf69874b5b..c8dafb1ac54e 100644
+--- a/sound/soc/sof/sof-acpi-dev.c
++++ b/sound/soc/sof/sof-acpi-dev.c
+@@ -15,10 +15,7 @@
+ #include <sound/soc-acpi.h>
+ #include <sound/soc-acpi-intel-match.h>
+ #include <sound/sof.h>
+-#ifdef CONFIG_X86
+-#include <asm/iosf_mbi.h>
+-#endif
+-
++#include "../intel/common/soc-intel-quirks.h"
+ #include "ops.h"
+ 
+ /* platform specific devices */
+@@ -99,56 +96,6 @@ static const struct sof_dev_desc sof_acpi_baytrail_desc = {
+ 	.arch_ops = &sof_xtensa_arch_ops
+ };
+ 
+-#ifdef CONFIG_X86 /* TODO: move this to common helper */
+-
+-static bool is_byt_cr(struct platform_device *pdev)
+-{
+-	struct device *dev = &pdev->dev;
+-	int status;
+-
+-	if (iosf_mbi_available()) {
+-		u32 bios_status;
+-		status = iosf_mbi_read(BT_MBI_UNIT_PMC, /* 0x04 PUNIT */
+-				       MBI_REG_READ, /* 0x10 */
+-				       0x006, /* BIOS_CONFIG */
+-				       &bios_status);
+-
+-		if (status) {
+-			dev_err(dev, "could not read PUNIT BIOS_CONFIG\n");
+-		} else {
+-			/* bits 26:27 mirror PMIC options */
+-			bios_status = (bios_status >> 26) & 3;
+-
+-			if (bios_status == 1 || bios_status == 3) {
+-				dev_info(dev, "Detected Baytrail-CR platform\n");
+-				return true;
+-			}
+-
+-			dev_info(dev, "BYT-CR not detected\n");
+-		}
+-	} else {
+-		dev_info(dev, "IOSF_MBI not available, no BYT-CR detection\n");
+-	}
+-
+-	if (platform_get_resource(pdev, IORESOURCE_IRQ, 5) == NULL) {
+-		/*
+-		 * Some devices detected as BYT-T have only a single IRQ listed,
+-		 * causing platform_get_irq with index 5 to return -ENXIO.
+-		 * The correct IRQ in this case is at index 0, as on BYT-CR.
+-		 */
+-		dev_info(dev, "Falling back to Baytrail-CR platform\n");
+-		return true;
+-	}
+-
+-	return false;
+-}
+-#else
+-static int is_byt_cr(struct platform_device *pdev)
+-{
+-	return 0;
+-}
+-#endif
+-
+ static const struct sof_dev_desc sof_acpi_cherrytrail_desc = {
+ 	.machines = snd_soc_acpi_intel_cherrytrail_machines,
+ 	.resindex_lpe_base = 0,
+@@ -200,7 +147,7 @@ static int sof_acpi_probe(struct platform_device *pdev)
+ 		return -ENODEV;
+ 
+ #if IS_ENABLED(CONFIG_SND_SOC_SOF_BAYTRAIL)
+-	if (desc == &sof_acpi_baytrail_desc && is_byt_cr(pdev))
++	if (desc == &sof_acpi_baytrail_desc && soc_intel_is_byt_cr(pdev))
+ 		desc = &sof_acpi_baytrailcr_desc;
+ #endif
+ 
+-- 
+2.22.0
+
+
+From 4a1a1da31e98e90fff056cfabec65028fdfd05b7 Mon Sep 17 00:00:00 2001
+From: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>
+Date: Thu, 30 May 2019 06:50:13 -0500
+Subject: [PATCH 2/4] ASoC: Intel: boards: remove dependency on
+ asm/platform_sst_audio.h
+
+This is not needed. Probably a copy/paste that was never removed.
+
+Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>
+Signed-off-by: Mark Brown <broonie@kernel.org>
+(am from https://git.kernel.org/broonie/sound/c/0d365acbbe295a67df5e1dc1e3661dc37390dd58)
+Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>
+---
+ sound/soc/intel/boards/bytcht_da7213.c | 1 -
+ sound/soc/intel/boards/bytcht_es8316.c | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/sound/soc/intel/boards/bytcht_da7213.c b/sound/soc/intel/boards/bytcht_da7213.c
+index ceeba7dc3ec8..97619a7d23a7 100644
+--- a/sound/soc/intel/boards/bytcht_da7213.c
++++ b/sound/soc/intel/boards/bytcht_da7213.c
+@@ -15,7 +15,6 @@
+ #include <linux/acpi.h>
+ #include <linux/platform_device.h>
+ #include <linux/slab.h>
+-#include <asm/platform_sst_audio.h>
+ #include <sound/pcm.h>
+ #include <sound/pcm_params.h>
+ #include <sound/soc.h>
+diff --git a/sound/soc/intel/boards/bytcht_es8316.c b/sound/soc/intel/boards/bytcht_es8316.c
+index e7fc4f1707e6..ac0073ee1678 100644
+--- a/sound/soc/intel/boards/bytcht_es8316.c
++++ b/sound/soc/intel/boards/bytcht_es8316.c
+@@ -22,7 +22,6 @@
+ #include <linux/module.h>
+ #include <linux/platform_device.h>
+ #include <linux/slab.h>
+-#include <asm/platform_sst_audio.h>
+ #include <sound/jack.h>
+ #include <sound/pcm.h>
+ #include <sound/pcm_params.h>
+-- 
+2.22.0
+
+
+From d43d97308c17c9a10b4615e8537a2d0ce50b65fb Mon Sep 17 00:00:00 2001
+From: Tri Vo <trong@android.com>
+Date: Wed, 22 May 2019 17:56:57 -0700
+Subject: [PATCH 3/4] ARM: disable FUNCTION_TRACER when building with Clang
+
+Clang needs "-meabi gnu" flag to emit calls to "__gnu_mcount_nc".
+Otherwise, it inserts calls to undefined "mcount".
+
+  kernel/softirq.o: In function `_local_bh_enable':
+  ...
+  undefined reference to `mcount'
+
+"-meabi gnu" resolves link failures.  However, Clang does not implement
+calls to "__gnu_mcount_nc" correctly.  It does not save the link
+register on the stack, which corrupts the stack.  The resulting kernel
+does not boot.
+
+Disable FUNCTION_TRACER support when building with Clang.
+
+Link: https://github.com/ClangBuiltLinux/linux/issues/35
+Suggested-by: Stefan Agner <stefan@agner.ch>
+Signed-off-by: Tri Vo <trong@android.com>
+(am from https://lore.kernel.org/lkml/20190523005657.170008-1-trong@android.com/)
+Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>
+---
+ arch/arm/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/Kconfig b/arch/arm/Kconfig
+index 8869742a85df..7a1804392795 100644
+--- a/arch/arm/Kconfig
++++ b/arch/arm/Kconfig
+@@ -75,7 +75,7 @@ config ARM
+ 	select HAVE_EXIT_THREAD
+ 	select HAVE_FTRACE_MCOUNT_RECORD if !XIP_KERNEL
+ 	select HAVE_FUNCTION_GRAPH_TRACER if !THUMB2_KERNEL && !CC_IS_CLANG
+-	select HAVE_FUNCTION_TRACER if !XIP_KERNEL
++	select HAVE_FUNCTION_TRACER if !XIP_KERNEL && !CC_IS_CLANG
+ 	select HAVE_GCC_PLUGINS
+ 	select HAVE_HW_BREAKPOINT if PERF_EVENTS && (CPU_V6 || CPU_V6K || CPU_V7)
+ 	select HAVE_IDE if PCI || ISA || PCMCIA
+-- 
+2.22.0
+
+
+From dd419f0f93fbc5b65380b0da5db79f9866763881 Mon Sep 17 00:00:00 2001
+From: Nathan Chancellor <natechancellor@gmail.com>
+Date: Tue, 11 Jun 2019 16:40:03 -0700
+Subject: [PATCH 4/4] ARM/ARM64: Force little endian for allyesconfig
+
+We want to use ld.lld to link and we want to avoid using the
+KCONFIG_ALLCONFIG environment variable.
+
+Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>
+---
+ arch/arm/mm/Kconfig | 2 +-
+ arch/arm64/Kconfig  | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/mm/Kconfig b/arch/arm/mm/Kconfig
+index b169e580bf82..0dea016dd951 100644
+--- a/arch/arm/mm/Kconfig
++++ b/arch/arm/mm/Kconfig
+@@ -741,7 +741,7 @@ config SWP_EMULATE
+ 
+ config CPU_BIG_ENDIAN
+ 	bool "Build big-endian kernel"
+-	depends on ARCH_SUPPORTS_BIG_ENDIAN
++	depends on BROKEN
+ 	help
+ 	  Say Y if you plan on running a kernel in big-endian mode.
+ 	  Note that your board must be properly built and your board
+diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
+index 697ea0510729..1980f089efaa 100644
+--- a/arch/arm64/Kconfig
++++ b/arch/arm64/Kconfig
+@@ -808,6 +808,7 @@ config ARM64_PA_BITS
+ 
+ config CPU_BIG_ENDIAN
+        bool "Build big-endian kernel"
++       depends on BROKEN
+        help
+          Say Y if you plan on running a kernel in big-endian mode.
+ 
+-- 
+2.22.0
+

--- a/utils.py
+++ b/utils.py
@@ -50,7 +50,9 @@ def download_binutils(folder):
                        check=True)
         verify_checksum(binutils_tarball)
         # Extract the tarball then remove it
-        subprocess.run(["tar", "-xzf", binutils_tarball.name], check=True, cwd=folder.as_posix())
+        subprocess.run(["tar", "-xzf", binutils_tarball.name],
+                       check=True,
+                       cwd=folder.as_posix())
         create_gitignore(binutils_folder)
         binutils_tarball.unlink()
 


### PR DESCRIPTION
The first patch fixes a couple of shellcheck warnings.

The second patch allows the kernel build script to do allyesconfig builds, which can be helpful for benchmarking changes like PGO and adding assertions. The commit message explains more.

The third patch just formats `utils.py` with [YAPF](https://github.com/google/yapf).

Let me know if there are any concerns.