### PR TITLE
build-llvm.py: Disable compiler-rt sanitizers for stage 1 bootstraps

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -554,6 +554,9 @@ def project_target_cmake_defines(args, stage):
         defines['COMPILER_RT_BUILD_BUILTINS'] = 'OFF'
         defines['COMPILER_RT_BUILD_CRT'] = 'OFF'
         defines['COMPILER_RT_BUILD_XRAY'] = 'OFF'
+        # We don't need the sanitizers for the stage 1 bootstrap
+        if bootstrap_stage(args, stage):
+            defines['COMPILER_RT_BUILD_SANITIZERS'] = 'OFF'
 
     return defines
 


### PR DESCRIPTION
We don't need them and it significantly reduces the targets on a stage 1
PGO build:

Targets before: 3513
Targets after: 2661