### PR TITLE
build-llvm.py: Add '--assertions'

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -45,6 +45,13 @@ def parse_parameters(root_folder):
     """
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument("--assertions",
+                        help=textwrap.dedent("""\
+                        In a release configuration, assertions are not enabled. This can help catch issues during
+                        compilation but it will increase compile times by 15-20%%.
+
+                        """),
+                        action="store_true")
     parser.add_argument("-b",
                         "--branch",
                         help=textwrap.dedent("""\
@@ -590,6 +597,8 @@ def stage_specific_cmake_defines(args, dirs, stage):
             defines['CMAKE_BUILD_TYPE'] = 'Release'
             defines['LLVM_ENABLE_WARNINGS'] = 'OFF'
             defines['LLVM_INCLUDE_TESTS'] = 'OFF'
+            if args.assertions:
+                defines['LLVM_ENABLE_ASSERTIONS'] = 'ON'
 
         # Where the toolchain should be installed
         defines['CMAKE_INSTALL_PREFIX'] = dirs.install_folder.as_posix()


### PR DESCRIPTION
There was an issue with https://github.com/llvm/llvm-project/commit/5354c83ece00690b4dbfa47925f8f5a8f33f1d9e that only appears when
assertions are enabled (because it only adds an assertion). Add a way to
turn them on in a release configuration so that compiles are still
relatively quick.