### PR TITLE
kernel/build.sh: Show make command using set -x and only show warnings/errors

### DIFF
--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -85,7 +85,9 @@ done
 
 # SC2191: The = here is literal. To assign by index, use ( [index]=value ) with no spaces. To keep as literal, quote it.
 # shellcheck disable=SC2191
-MAKE=( make -j"$(nproc)" CC=clang O=out )
+MAKE=( make -j"$(nproc)" -s CC=clang O=out )
+
+set -x
 
 for TARGET in "${TARGETS[@]}"; do
     case ${TARGET} in


### PR DESCRIPTION
This will make it easier to audit build failures because the exact make
command can be copy and pasted from the terminal.