### PR TITLE
README.md: Add flex and bison to needed packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ These scripts have been tested in a Docker image of the following distributions,
 * ### Debian/Ubuntu
 
   ```
-  apt install ca-certificates ccache clang cmake curl file gcc g++ git make ninja-build python3 texinfo zlib1g-dev bison flex
+  apt install bison ca-certificates ccache clang cmake curl file flex gcc g++ git make ninja-build python3 texinfo zlib1g-dev
   ```
 
   On Debian Buster or Ubuntu Bionic/Cosmic/Disco, `apt install lld` should be added as well for faster compiles.
@@ -27,13 +27,13 @@ These scripts have been tested in a Docker image of the following distributions,
 * ### Fedora
 
   ```
-  dnf install ccache clang cmake gcc gcc-c++ git lld make ninja-build python3 zlib-devel flex bison
+  dnf install bison ccache clang cmake flex gcc gcc-c++ git lld make ninja-build python3 zlib-devel
   ```
 
 * ### Arch Linux
 
   ```
-  pacman -S base-devel ccache clang cmake git lld ninja python3 flex bison
+  pacman -S base-devel bison ccache clang cmake flex git lld ninja python3
   ```
 
 If you intend to compile with PGO, please ensure that you also have `bc` and `libssl-dev` (or equivalent) installed as you will be building some Linux kernels. If you are building for PowerPC (which the script does by default), make sure `mkimage` is available as well; the package is `u-boot-tools` on Debian/Ubuntu.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ These scripts have been tested in a Docker image of the following distributions,
 * ### Debian/Ubuntu
 
   ```
-  apt install ca-certificates ccache clang cmake curl file gcc g++ git make ninja-build python3 texinfo zlib1g-dev
+  apt install ca-certificates ccache clang cmake curl file gcc g++ git make ninja-build python3 texinfo zlib1g-dev bison flex
   ```
 
   On Debian Buster or Ubuntu Bionic/Cosmic/Disco, `apt install lld` should be added as well for faster compiles.
@@ -27,16 +27,16 @@ These scripts have been tested in a Docker image of the following distributions,
 * ### Fedora
 
   ```
-  dnf install ccache clang cmake gcc gcc-c++ git lld make ninja-build python3 zlib-devel
+  dnf install ccache clang cmake gcc gcc-c++ git lld make ninja-build python3 zlib-devel flex bison
   ```
 
 * ### Arch Linux
 
   ```
-  pacman -S base-devel ccache clang cmake git lld ninja python3
+  pacman -S base-devel ccache clang cmake git lld ninja python3 flex bison
   ```
 
-If you intend to compile with PGO, please ensure that you also have `bc`, `bison`,`flex`, and `libssl-dev` (or equivalent) installed as you will be building some Linux kernels. If you are building for PowerPC (which the script does by default), make sure `mkimage` is available as well; the package is `u-boot-tools` on Debian/Ubuntu.
+If you intend to compile with PGO, please ensure that you also have `bc` and `libssl-dev` (or equivalent) installed as you will be building some Linux kernels. If you are building for PowerPC (which the script does by default), make sure `mkimage` is available as well; the package is `u-boot-tools` on Debian/Ubuntu.
 
 Python 3.5.3+ is recommended, as that is what the script has been tested against. These scripts should be distribution agnostic. Please feel free to add different distribution install commands here through a pull request.
 


### PR DESCRIPTION
as binutils build request it, otherwise the build fails:
binutils/missing: 81: binutils/missing: flex: not found
WARNING: 'flex' is missing on your system.
         You should only need it if you modified a '.l' file.
         You may want to install the Fast Lexical Analyzer package:
         <http://flex.sourceforge.net/>
make[2]: *** [Makefile:1108: syslex.c] Error 127

binutils/missing: 81: binutils/missing: bison: not found
WARNING: 'bison' is missing on your system.
         You should only need it if you modified a '.y' file.
         You may want to install the GNU Bison package:
         <http://www.gnu.org/software/bison/>
make[2]: *** [Makefile:1111: sysinfo.c] Error 127