### PR TITLE
build-llvm.py: Look for clang-11 when building stage 1

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -267,17 +267,22 @@ def versioned_binaries(binary_name):
     :return: List of versioned binaries
     """
 
-    # There might be clang-6 to clang-11
+    # There might be clang-7 to clang-11
     tot_llvm_ver = 11
     try:
         response = request.urlopen(
             'https://raw.githubusercontent.com/llvm/llvm-project/master/llvm/CMakeLists.txt'
         )
-        data = response.read().decode('utf-8')
-        tot_llvm_ver = re.search(r'^.*LLVM_VERSION_MAJOR\ (\d{2})\)', data).group(0)
+        to_parse = None
+        data = response.readlines()
+        for line in data:
+            line = line.decode('utf-8').strip()
+            if "set(LLVM_VERSION_MAJOR" in line:
+                to_parse = line
+        tot_llvm_ver = re.search('\d+', to_parse).group(0)
     except URLError:
         pass
-    return ['%s-%s' % (binary_name, i) for i in range(tot_llvm_ver, 5, -1)]
+    return ['%s-%s' % (binary_name, i) for i in range(int(tot_llvm_ver), 6, -1)]
 
 
 def check_cc_ld_variables(root_folder):

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -11,6 +11,8 @@ import shutil
 import textwrap
 import time
 import utils
+import re
+import urllib.request as request
 
 # This is a known good revision of LLVM for building the kernel
 # To bump this, run 'PATH_OVERRIDE=<path_to_updated_toolchain>/bin kernel/build.sh --allyesconfig'
@@ -265,7 +267,11 @@ def versioned_binaries(binary_name):
     """
 
     # There might be clang-6 to clang-11
-    tot_llvm_ver = 11
+    response = request.urlopen(
+        'https://raw.githubusercontent.com/llvm/llvm-project/master/llvm/CMakeLists.txt'
+    )
+    data = response.read().decode('utf-8')
+    tot_llvm_ver = re.search(r'^.*LLVM_VERSION_MAJOR\ (\d{2})\)', data).group(0)
     return ['%s-%s' % (binary_name, i) for i in range(tot_llvm_ver, 5, -1)]
 
 

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -13,6 +13,7 @@ import time
 import utils
 import re
 import urllib.request as request
+from urllib.error import URLError
 
 # This is a known good revision of LLVM for building the kernel
 # To bump this, run 'PATH_OVERRIDE=<path_to_updated_toolchain>/bin kernel/build.sh --allyesconfig'
@@ -267,11 +268,15 @@ def versioned_binaries(binary_name):
     """
 
     # There might be clang-6 to clang-11
-    response = request.urlopen(
-        'https://raw.githubusercontent.com/llvm/llvm-project/master/llvm/CMakeLists.txt'
-    )
-    data = response.read().decode('utf-8')
-    tot_llvm_ver = re.search(r'^.*LLVM_VERSION_MAJOR\ (\d{2})\)', data).group(0)
+    tot_llvm_ver = 11
+    try:
+        response = request.urlopen(
+            'https://raw.githubusercontent.com/llvm/llvm-project/master/llvm/CMakeLists.txt'
+        )
+        data = response.read().decode('utf-8')
+        tot_llvm_ver = re.search(r'^.*LLVM_VERSION_MAJOR\ (\d{2})\)', data).group(0)
+    except URLError:
+        pass
     return ['%s-%s' % (binary_name, i) for i in range(tot_llvm_ver, 5, -1)]
 
 

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -264,8 +264,9 @@ def versioned_binaries(binary_name):
     :return: List of versioned binaries
     """
 
-    # There might be clang-6 to clang-10
-    return ['%s-%s' % (binary_name, i) for i in range(10, 5, -1)]
+    # There might be clang-6 to clang-11
+    tot_llvm_ver = 11
+    return ['%s-%s' % (binary_name, i) for i in range(tot_llvm_ver, 5, -1)]
 
 
 def check_cc_ld_variables(root_folder):

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -279,6 +279,7 @@ def versioned_binaries(binary_name):
             line = line.decode('utf-8').strip()
             if "set(LLVM_VERSION_MAJOR" in line:
                 to_parse = line
+                break
         tot_llvm_ver = re.search('\d+', to_parse).group(0)
     except URLError:
         pass

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -282,7 +282,9 @@ def versioned_binaries(binary_name):
         tot_llvm_ver = re.search('\d+', to_parse).group(0)
     except URLError:
         pass
-    return ['%s-%s' % (binary_name, i) for i in range(int(tot_llvm_ver), 6, -1)]
+    return [
+        '%s-%s' % (binary_name, i) for i in range(int(tot_llvm_ver), 6, -1)
+    ]
 
 
 def check_cc_ld_variables(root_folder):


### PR DESCRIPTION
Also, add a variable so this becomes easier to bump. Eventually, I would like to do this similar to `driver.sh` in the CI repo where we just grab the latest version from the LLVM repo but that becomes hard in Python...