### PR TITLE
build-llvm.py: Enable Polly by default

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -220,7 +220,7 @@ def parse_parameters(root_folder):
 
                         """),
                         type=str,
-                        default="clang;lld;compiler-rt")
+                        default="clang;compiler-rt;lld;polly")
     parser.add_argument("--pgo",
                         help=textwrap.dedent("""\
                         Build the final compiler with PGO, which can improve compile time performance.


### PR DESCRIPTION
More and more Android kernel developers are starting to enable Polly.
This was recently enabled in AOSP's LLVM builds:

https://android.googlesource.com/toolchain/llvm_android/+/6ba474f9d931f696860cec49b8c1dd62ac1e5a46

Do the same thing in our build. It only adds approximately 150 targets
to the final LLVM stage (comparing --build-stage1-only with and without
this patch, 3714 -> 3870).

While we're at it, alphabetize the projects.

cc @kdrag0n @0ctobot @lazerl0rd