### PR TITLE
README: Document manual LLVM source management

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Python 3.5.3+ is recommended, as that is what the script has been tested against
 
 By default, `./build-llvm.py` will clone LLVM, grab the latest binutils tarball (for the LLVMgold.so plugin), and build LLVM, clang, and lld, and install them into `install`.
 
-The script automatically clones and manages the [`llvm-project`](https://github.com/llvm/llvm-project). If you would like to do this management yourself, such as downloading a release tarball from [releases.llvm.org](https://releases.llvm.org/), doing a more aggressive shallow clone (versus what is done in the script via `--shallow-clone`), or doing a bisection of LLVM, you just need to make sure that your source is in an `llvm-project` folder within the root of this repository and pass `--no-update` into the script.
+The script automatically clones and manages the [`llvm-project`](https://github.com/llvm/llvm-project). If you would like to do this management yourself, such as downloading a release tarball from [releases.llvm.org](https://releases.llvm.org/), doing a more aggressive shallow clone (versus what is done in the script via `--shallow-clone`), or doing a bisection of LLVM, you just need to make sure that your source is in an `llvm-project` folder within the root of this repository and pass `--no-update` into the script. See [this comment](https://github.com/ClangBuiltLinux/tc-build/issues/75#issuecomment-604374071) for an example.
 
 Run `./build-llvm.py -h` for more options and information.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,11 @@ Python 3.5.3+ is recommended, as that is what the script has been tested against
 
 ## build-llvm.py
 
-By default, `./build-llvm.py` will clone LLVM, grab the latest binutils tarball (for the LLVMgold.so plugin), and build LLVM, clang, and lld, and install them into `install`. Run `./build-llvm.py -h` for more options.
+By default, `./build-llvm.py` will clone LLVM, grab the latest binutils tarball (for the LLVMgold.so plugin), and build LLVM, clang, and lld, and install them into `install`.
+
+The script automatically clones and manages the [`llvm-project`](https://github.com/llvm/llvm-project). If you would like to do this management yourself, such as downloading a release tarball from [releases.llvm.org](https://releases.llvm.org/), doing a more aggressive shallow clone (versus what is done in the script via `--shallow-clone`), or doing a bisection of LLVM, you just need to make sure that your source is in an `llvm-project` folder within the root of this repository and pass `--no-update` into the script.
+
+Run `./build-llvm.py -h` for more options and information.
 
 ## build-binutils.py
 


### PR DESCRIPTION
Users can manually manage LLVM's source if they need to, either due to
space/time requirements or doing things like bisection. Document this.

Closes: #75

cc @dileks 