### PR TITLE
README: Update a few package lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ These scripts have been tested in a Docker image of the following distributions,
               python3 \
               texinfo \
               u-boot-tools \
+              xz-utils \
               zlib1g-dev
   ```
 
@@ -61,7 +62,9 @@ These scripts have been tested in a Docker image of the following distributions,
               ninja-build \
               openssl-devel \
               python3 \
+              texinfo-tex \
               uboot-tools \
+              xz \
               zlib-devel
   ```
 


### PR DESCRIPTION
In my Docker image tests, these couple of packages are necessary for
the build to complete properly.

xz is required after we switched to xz compression on Linux/binutils
tarballs.

texinfo has always been required but I must have left it off by accident
for Fedora since it is there for Debian/Ubuntu. It is a part of the
base-devel group on Arch Linux so no need to update it.