### PR TITLE
Revert "build-llvm.py: Only enable assertions on the final build"

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -703,6 +703,11 @@ def stage_specific_cmake_defines(args, dirs, stage):
         if args.build_type == "Release":
             defines['LLVM_ENABLE_WARNINGS'] = 'OFF'
 
+        # Build with assertions enabled if requested (will slow down compilation
+        # so it is not on by default)
+        if args.assertions:
+            defines['LLVM_ENABLE_ASSERTIONS'] = 'ON'
+
         # Where the toolchain should be installed
         defines['CMAKE_INSTALL_PREFIX'] = dirs.install_folder.as_posix()
 
@@ -718,11 +723,6 @@ def stage_specific_cmake_defines(args, dirs, stage):
                     "profdata.prof").as_posix()
             if args.lto:
                 defines['LLVM_ENABLE_LTO'] = args.lto.capitalize()
-
-            # Build with assertions enabled if requested (will slow down compilation
-            # so it is not on by default)
-            if args.assertions:
-                defines['LLVM_ENABLE_ASSERTIONS'] = 'ON'
 
     return defines
 


### PR DESCRIPTION
This reverts commit 04630c0621e607b260cbc12073feeaf2d13c96c1.

This was actually a bad idea. If assertions are not enabled when doing
PGO, they cannot be taken into account when optimizing hot paths.

Sample kernel build times with a PGO'd clang without assertions:

```
arm32 allyesconfig: 10m 48s
arm64 allyesconfig: 12m 21s
x86_64 allyesconfig: 14m 30s
```

Sample kernel build times with a PGO'd clang with assertions without
this patch:

```
arm32 allyesconfig: 14m 57s
arm64 allyesconfig: 17m 51s
x86_64 allyesconfig: 19m 24s
```

Sample kernel build times with a PGO'd clang with assertions with this
patch:

```
arm32 allyesconfig: 12m 24s
arm64 allyesconfig: 13m 55s
x86_64 allyesconfig: 15m 53s
```