### PR TITLE
Reformat shell scripts with shfmt and validate in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 # Run a couple of linters on code in repo
-# * shellcheck for shell scripts
+# * shellcheck and shfmt for shell scripts
 # * YAPF for Python scripts
 name: Lint checks
 on: [push, pull_request]
@@ -16,3 +16,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: yapf
       uses: AlexanderMelde/yapf-action@master
+  shfmt-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.14.2'
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Run shfmt
+      run: |
+        GO111MODULE=on go get mvdan.cc/sh/v3/cmd/shfmt
+        while read -r f; do
+          PATH=$HOME/go/bin:$PATH shfmt -ci -d -i 4 $f
+        done < <(find . -type f -name "*.sh")

--- a/clang-version.sh
+++ b/clang-version.sh
@@ -8,9 +8,9 @@
 
 compiler="$*"
 
-if ! ( $compiler --version | grep -q clang) ; then
-	echo 0
-	exit 1
+if ! ($compiler --version | grep -q clang); then
+    echo 0
+    exit 1
 fi
 
 MAJOR=$(echo __clang_major__ | $compiler -E -x c - | tail -n 1)


### PR DESCRIPTION
Uses [mvdan/sh](https://github.com/mvdan/sh) to enable formatting checks in CI, and correctly fails when the codestyle is [incorrect](https://github.com/msfjarvis/boot-utils/actions/runs/85612538), outputting a diff with fixes.

I chose the set of options that made the most sense to me, all available switches are listed [here](https://bin.msfjarvis.dev/~5ea167531de3ad00122e4ec0).
