### PR TITLE
build-llvm.py: Don't use versioned_binaries for ld.lld

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -381,9 +381,7 @@ def check_cc_ld_variables(root_folder):
     else:
         # and we're using clang, try to find the fastest one
         if "clang" in cc:
-            possible_linkers = versioned_binaries("lld") + [
-                'lld', 'gold', 'bfd'
-            ]
+            possible_linkers = ['lld', 'gold', 'bfd']
             for linker in possible_linkers:
                 # We want to find lld wherever the clang we are using is located
                 ld = shutil.which("ld." + linker,


### PR DESCRIPTION
I added the versioned binaries to handle the case where someone was
using apt.llvm.org binaries, where a version number is suffixed to the
binary name:

```
$ command -v ld.lld-11
/usr/bin/ld.lld-11
$ ls -l /usr/bin/ld.lld-11
lrwxrwxrwx 1 root root 25 May  2 08:32 /usr/bin/ld.lld-11 -> ../lib/llvm-11/bin/ld.lld
```

Before this patch, we would just use `/usr/bin/ld.lld-11` for
`-fuse-ld=` instead of resolving the symlink and using
`/usr/lib/llvm-11/bin/ld.lld` for `-fuse-ld=`.

However, this causes an issue where a user might be using their own
installation of LLVM and be using stock Debian/Ubuntu or apt.llvm.org
binaries at the same time (see the first entry in the before this
patch section below).

The versioned_binaries call is unnecessary because the script can handle
the apt.llvm.org case just fine. We resolve symlinks to get LLVM's `bin`
folder when getting `CC`'s value and we prioritize that folder via a `PATH`
modification when locating `LD` so we will always find `ld.lld` in the same
folder that `clang` is in.

Before this patch:

```
$ ./build-llvm.py
...
CC: /home/nathan/toolchains/llvm/2020-04-30/bin/clang-11
CXX: /home/nathan/toolchains/llvm/2020-04-30/bin/clang++
LD: /usr/bin/ld.lld-10
...

$ CC=clang PATH=/usr/bin:${PATH} ./build-llvm.py
...
CC: /usr/lib/llvm-10/bin/clang
CXX: /usr/lib/llvm-10/bin/clang++
LD: /usr/bin/ld.lld-10
...
```

After this patch:

```
$ ./build-llvm.py
...
CC: /home/nathan/toolchains/llvm/2020-04-30/bin/clang-11
CXX: /home/nathan/toolchains/llvm/2020-04-30/bin/clang++
LD: /home/nathan/toolchains/llvm/2020-04-30/bin/ld.lld
...

$ CC=clang PATH=/usr/bin:${PATH} ./build-llvm.py
...
CC: /usr/lib/llvm-10/bin/clang
CXX: /usr/lib/llvm-10/bin/clang++
LD: /usr/lib/llvm-10/bin/ld.lld
...
```

I tested several Docker images and found that this patch does not change
the behavior for any stock installations of LLVM. An upgrade to Ubuntu
Focal exposed this because previously, Ubuntu Bionic's LLVM version was
not even factored in to the search for `ld.lld` (LLVM 6, we start at LLVM
7), but Ubuntu Focal's LLVM version (10) is.