### PR TITLE
build-llvm.py: Update known good revision

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -17,7 +17,7 @@ from urllib.error import URLError
 
 # This is a known good revision of LLVM for building the kernel
 # To bump this, run 'PATH_OVERRIDE=<path_to_updated_toolchain>/bin kernel/build.sh --allyesconfig'
-GOOD_REVISION = 'ebad678857a94c32ce7b6931e9c642b32d278b67'
+GOOD_REVISION = '8a5aea7b50429cd4a459511286a7a9f1a7f4f5e2'
 
 
 class Directories:


### PR DESCRIPTION
This has been qualified with llvm-kernel-testing, which builds several
different configurations on four different kernel versions with
assertions enabled.

Normally, this would be done with the Linux 5.7 update but KCSAN, an
upcoming 5.8 feature, is requiring clang 11 or newer and some kernel
developers have expressed minor displeasure with that as they do not
want to deal with compiler issues. This option is meant specifically for
that use case and so we bump this to a revision that is new enough to
have the commits that KCSAN needs to work.

I am planning to do this on a monthly basis from now on, rather than
every Linux release.

Link: https://lore.kernel.org/lkml/20200520034426.GA1027673@ubuntu-s3-xlarge-x86/
Link: https://github.com/nathanchance/llvm-kernel-testing