### PR TITLE
workflows: upgrade action/cache to latest version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.14.2'
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2.0.0
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go


### PR DESCRIPTION
What's Changed:

Added support for multiple paths, glob patterns, and single file caches 
**Increased performance and improved cache sizes using zstd for compression for Linux and macOS runners** 
Allowed caching for all events with a ref 
Created the @actions/cache npm package to allow other actions to utilize caching 
Added a best-effort step to delete the archive after extraction to reduces storage space 
Improved reliability of the download cache APIs 
Added retries to API calls that failed due to retryable errors 
Improved error handling during both cache upload and download
Increase cache size limit to 5 GB 
Add proxy support 
Improved reliability and speed of cache upload via chunked APIs
Increased per-cache size limit to 2 GB to match the per-repo limit

For further reference :
https://github.com/actions/cache/releases