### PR TITLE
workflows: some minor improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
       - master
 jobs:
   build-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ name: Lint checks
 on: [push, pull_request]
 jobs:
   shellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: shellcheck
@@ -17,13 +17,13 @@ jobs:
     - name: yapf
       uses: AlexanderMelde/yapf-action@master
   shfmt-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
         go-version: '1.14.2'
-    - uses: actions/cache@v2.0.0
+    - uses: actions/cache@v2
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go


### PR DESCRIPTION
*The advantage of using just @v2 instead of @v2.x.x versioning format is that minor releases and patches are included without requiring a change.

*The "ubuntu-latest" YAML workflow label still uses the Ubuntu 18.04 virtual environment which is not latest.
So switch to latest available runner which is ubuntu-20.04