### PR TITLE
Fix header formatting for kernel buildscript

### DIFF
--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -6,7 +6,7 @@ TC_BLD=$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"/.. && pwd)
 
 function header() {
     BORDER="====$(for _ in $(seq ${#1}); do printf '='; done)===="
-    printf '\033[1m\n%s\n%s\n%s\n\n\033[0m' "${BORDER}" "==  ${1}  ==" "${BORDER}"
+    printf '\033[1m\n%s\n%s\n%s\n\n\033[0m' "${BORDER}" "== ${1} ==" "${BORDER}"
 }
 
 # Parse parameters


### PR DESCRIPTION
As suggested in #112, but I discarded the naming changes since I don't necessarily agree with them.