### PR TITLE
build-llvm.py: Enable BPF backend by default

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -293,11 +293,12 @@ def parse_parameters(root_folder):
 
                                """),
                                action="store_true")
+    # yapf: disable
     parser.add_argument("-t",
                         "--targets",
                         help=textwrap.dedent("""\
                         LLVM is multitargeted by default. Currently, this script only enables the arm32, aarch64,
-                        mips, powerpc, riscv, s390, and x86 backends because that's what the Linux kernel is
+                        bpf, mips, powerpc, riscv, s390, and x86 backends because that's what the Linux kernel is
                         currently concerned with. If you would like to override this, you can use this parameter
                         and supply a list that is supported by LLVM_TARGETS_TO_BUILD:
 
@@ -307,7 +308,8 @@ def parse_parameters(root_folder):
 
                         """),
                         type=str,
-                        default="AArch64;ARM;Mips;PowerPC;RISCV;SystemZ;X86")
+                        default="AArch64;ARM;BPF;Mips;PowerPC;RISCV;SystemZ;X86")
+    # yapf: enable
     clone_options.add_argument("--use-good-revision",
                                help=textwrap.dedent("""\
                         By default, the script updates LLVM to the latest tip of tree revision, which may at times be


### PR DESCRIPTION
This is needed for CONFIG_DEBUG_INFO_BTF, which is becoming increasingly
more common. Add it to the list of targets that are enabled by default
so that it can be used without any issues.

Closes: https://github.com/ClangBuiltLinux/tc-build/issues/129