### PR TITLE
kernel: Update to Linux 5.10.9

### DIFF
--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -74,7 +74,7 @@ ${PGO:=false} && export PATH=${BUILD_FOLDER:=${TC_BLD}/build/llvm}/stage2/bin:${
 if [[ -n ${SRC_FOLDER} ]]; then
     cd "${SRC_FOLDER}" || exit 1
 else
-    LINUX=linux-5.10
+    LINUX=linux-5.10.9
     LINUX_TARBALL=${TC_BLD}/kernel/${LINUX}.tar.xz
     LINUX_PATCH=${TC_BLD}/kernel/${LINUX}-${CONFIG_TARGET}.patch
 

--- a/kernel/linux-5.10.9.tar.xz.sha256
+++ b/kernel/linux-5.10.9.tar.xz.sha256
@@ -1,0 +1,1 @@
+7f733e0dd8bbb6929aae2191cf6b9dc0b0ec1dad77ab3f5d3aad1b7fe96c4751  linux-5.10.9.tar.xz

--- a/kernel/linux-5.10.tar.xz.sha256
+++ b/kernel/linux-5.10.tar.xz.sha256
@@ -1,1 +1,0 @@
-dcdf99e43e98330d925016985bfbc7b83c66d367b714b2de0cbbfcbf83d8ca43  linux-5.10.tar.xz


### PR DESCRIPTION
We need the below commit to continue to do PGO without any issues.

https://git.kernel.org/stable/c/cb5a170e979e7d1b15185c9943c546bda2bc6445