### PR TITLE
ci.sh: Use release/12.x for build testing

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -61,7 +61,7 @@ function do_llvm() {
     [[ -n ${GITHUB_ACTIONS:-} ]] && EXTRA_ARGS+=(--no-ccache)
     "${BASE}"/build-llvm.py \
         --assertions \
-        --branch "release/10.x" \
+        --branch "release/12.x" \
         --build-stage1-only \
         --check-targets clang lld llvm \
         --install-stage1-only \


### PR DESCRIPTION
This will be the latest version of LLVM shortly so let's cut over now to
get ahead of testing early.