### PR TITLE
Simplify the flags in build-binutils.py

### DIFF
--- a/build-binutils.py
+++ b/build-binutils.py
@@ -169,7 +169,6 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
         ],
         "mips-linux-gnu": [
             '--disable-compressed-debug-sections', '--enable-new-dtags',
-            '--enable-shared',
             '--enable-targets=mips64-linux-gnuabi64,mips64-linux-gnuabin32',
             '--enable-threads'
         ],

--- a/build-binutils.py
+++ b/build-binutils.py
@@ -170,10 +170,6 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
             '--with-gnu-ld',
             '--with-sysroot=%s' % install_folder.joinpath(target).as_posix()
         ],
-        "mips-linux-gnu":
-        ['--enable-targets=mips64-linux-gnuabi64,mips64-linux-gnuabin32'],
-        "mipsel-linux-gnu":
-        ['--enable-targets=mips64el-linux-gnuabi64,mips64el-linux-gnuabin32'],
         "powerpc-linux-gnu":
         ['--enable-lto', '--enable-relro', '--disable-sim', '--with-pic'],
         "riscv64-linux-gnu":
@@ -193,6 +189,12 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
         'powerpc-linux-gnu']
     configure_arch_flags['powerpc64le-linux-gnu'] = configure_arch_flags[
         'powerpc-linux-gnu']
+
+    for endian in ["", "el"]:
+        configure_arch_flags['mips%s-linux-gnu' % (endian)] = [
+            '--enable-targets=mips64%s-linux-gnuabi64,mips64%s-linux-gnuabin32'
+            % (endian, endian)
+        ]
 
     configure += configure_arch_flags.get(target, [])
 

--- a/build-binutils.py
+++ b/build-binutils.py
@@ -152,7 +152,7 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
                              "configure").as_posix(), 'CC=gcc', 'CXX=g++',
         '--prefix=%s' % install_folder.as_posix(),
         '--enable-deterministic-archives', '--enable-plugins', '--quiet',
-        '--disable-werror'
+        '--disable-gdb', '--disable-werror'
     ]
     if host_arch:
         configure += [
@@ -180,7 +180,7 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
         ],
         "powerpc-linux-gnu": [
             '--enable-lto', '--enable-relro', '--enable-threads',
-            '--disable-gdb', '--disable-sim', '--with-pic',
+            '--disable-sim', '--with-pic',
             '--with-system-zlib'
         ],
         "riscv64-linux-gnu": [
@@ -190,11 +190,11 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
         "s390x-linux-gnu": [
             '--enable-lto', '--enable-relro',
             '--enable-targets=s390-linux-gnu', '--enable-threads',
-            '--disable-gdb', '--with-pic', '--with-system-zlib'
+            '--with-pic', '--with-system-zlib'
         ],
         "x86_64-linux-gnu": [
             '--enable-lto', '--enable-relro', '--enable-targets=x86_64-pep',
-            '--enable-threads', '--disable-gdb', '--with-pic',
+            '--enable-threads', '--with-pic',
             '--with-system-zlib'
         ]
     }

--- a/build-binutils.py
+++ b/build-binutils.py
@@ -172,16 +172,6 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
         ],
         "powerpc-linux-gnu":
         ['--enable-lto', '--enable-relro', '--disable-sim', '--with-pic'],
-        "riscv64-linux-gnu":
-        ['--enable-lto', '--enable-relro', '--disable-sim', '--with-pic'],
-        "s390x-linux-gnu": [
-            '--enable-lto', '--enable-relro',
-            '--enable-targets=s390-linux-gnu', '--with-pic'
-        ],
-        "x86_64-linux-gnu": [
-            '--enable-lto', '--enable-relro', '--enable-targets=x86_64-pep',
-            '--with-pic'
-        ]
     }
     configure_arch_flags['aarch64-linux-gnu'] = configure_arch_flags[
         'arm-linux-gnueabi'] + ['--enable-ld=default', '--enable-gold']
@@ -189,6 +179,12 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
         'powerpc-linux-gnu']
     configure_arch_flags['powerpc64le-linux-gnu'] = configure_arch_flags[
         'powerpc-linux-gnu']
+    configure_arch_flags['riscv64-linux-gnu'] = configure_arch_flags[
+        'powerpc-linux-gnu']
+    configure_arch_flags['s390x-linux-gnu'] = configure_arch_flags[
+        'powerpc-linux-gnu'] + ['--enable-targets=s390-linux-gnu']
+    configure_arch_flags['x86_64-linux-gnu'] = configure_arch_flags[
+        'powerpc-linux-gnu'] + ['--enable-targets=x86_64-pep']
 
     for endian in ["", "el"]:
         configure_arch_flags['mips%s-linux-gnu' % (endian)] = [

--- a/build-binutils.py
+++ b/build-binutils.py
@@ -153,7 +153,7 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
         '--prefix=%s' % install_folder.as_posix(),
         '--enable-deterministic-archives', '--enable-plugins', '--quiet',
         '--disable-gdb', '--disable-werror', '--with-system-zlib',
-        '--enable-threads'
+        '--enable-threads', '--disable-compressed-debug-sections'
     ]
     if host_arch:
         configure += [
@@ -170,11 +170,11 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
             '--with-sysroot=%s' % install_folder.joinpath(target).as_posix()
         ],
         "mips-linux-gnu": [
-            '--disable-compressed-debug-sections', '--enable-new-dtags',
+            '--enable-new-dtags',
             '--enable-targets=mips64-linux-gnuabi64,mips64-linux-gnuabin32'
         ],
         "mipsel-linux-gnu": [
-            '--disable-compressed-debug-sections', '--enable-new-dtags',
+            '--enable-new-dtags',
             '--enable-targets=mips64el-linux-gnuabi64,mips64el-linux-gnuabin32'
         ],
         "powerpc-linux-gnu":

--- a/build-binutils.py
+++ b/build-binutils.py
@@ -151,7 +151,8 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
         root_folder.joinpath(utils.current_binutils(),
                              "configure").as_posix(), 'CC=gcc', 'CXX=g++',
         '--prefix=%s' % install_folder.as_posix(),
-        '--enable-deterministic-archives', '--enable-plugins', '--quiet'
+        '--enable-deterministic-archives', '--enable-plugins', '--quiet',
+        '--disable-werror'
     ]
     if host_arch:
         configure += [
@@ -179,24 +180,22 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
         ],
         "powerpc-linux-gnu": [
             '--enable-lto', '--enable-relro', '--enable-threads',
-            '--disable-gdb', '--disable-sim', '--disable-werror', '--with-pic',
+            '--disable-gdb', '--disable-sim', '--with-pic',
             '--with-system-zlib'
         ],
         "riscv64-linux-gnu": [
             '--enable-lto', '--enable-relro', '--enable-threads',
-            '--disable-sim', '--disable-werror', '--with-pic',
-            '--with-system-zlib'
+            '--disable-sim', '--with-pic', '--with-system-zlib'
         ],
         "s390x-linux-gnu": [
             '--enable-lto', '--enable-relro',
             '--enable-targets=s390-linux-gnu', '--enable-threads',
-            '--disable-gdb', '--disable-werror', '--with-pic',
-            '--with-system-zlib'
+            '--disable-gdb', '--with-pic', '--with-system-zlib'
         ],
         "x86_64-linux-gnu": [
             '--enable-lto', '--enable-relro', '--enable-targets=x86_64-pep',
-            '--enable-threads', '--disable-gdb', '--disable-werror',
-            '--with-pic', '--with-system-zlib'
+            '--enable-threads', '--disable-gdb', '--with-pic',
+            '--with-system-zlib'
         ]
     }
     configure_arch_flags['aarch64-linux-gnu'] = configure_arch_flags[

--- a/build-binutils.py
+++ b/build-binutils.py
@@ -153,7 +153,8 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
         '--prefix=%s' % install_folder.as_posix(),
         '--enable-deterministic-archives', '--enable-plugins', '--quiet',
         '--disable-gdb', '--disable-werror', '--with-system-zlib',
-        '--enable-threads', '--disable-compressed-debug-sections'
+        '--enable-threads', '--disable-compressed-debug-sections',
+        '--enable-new-dtags'
     ]
     if host_arch:
         configure += [
@@ -169,14 +170,10 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
             '--with-gnu-ld',
             '--with-sysroot=%s' % install_folder.joinpath(target).as_posix()
         ],
-        "mips-linux-gnu": [
-            '--enable-new-dtags',
-            '--enable-targets=mips64-linux-gnuabi64,mips64-linux-gnuabin32'
-        ],
-        "mipsel-linux-gnu": [
-            '--enable-new-dtags',
-            '--enable-targets=mips64el-linux-gnuabi64,mips64el-linux-gnuabin32'
-        ],
+        "mips-linux-gnu":
+        ['--enable-targets=mips64-linux-gnuabi64,mips64-linux-gnuabin32'],
+        "mipsel-linux-gnu":
+        ['--enable-targets=mips64el-linux-gnuabi64,mips64el-linux-gnuabin32'],
         "powerpc-linux-gnu":
         ['--enable-lto', '--enable-relro', '--disable-sim', '--with-pic'],
         "riscv64-linux-gnu":

--- a/build-binutils.py
+++ b/build-binutils.py
@@ -152,7 +152,8 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
                              "configure").as_posix(), 'CC=gcc', 'CXX=g++',
         '--prefix=%s' % install_folder.as_posix(),
         '--enable-deterministic-archives', '--enable-plugins', '--quiet',
-        '--disable-gdb', '--disable-werror', '--with-system-zlib'
+        '--disable-gdb', '--disable-werror', '--with-system-zlib',
+        '--enable-threads'
     ]
     if host_arch:
         configure += [
@@ -170,29 +171,23 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
         ],
         "mips-linux-gnu": [
             '--disable-compressed-debug-sections', '--enable-new-dtags',
-            '--enable-targets=mips64-linux-gnuabi64,mips64-linux-gnuabin32',
-            '--enable-threads'
+            '--enable-targets=mips64-linux-gnuabi64,mips64-linux-gnuabin32'
         ],
         "mipsel-linux-gnu": [
             '--disable-compressed-debug-sections', '--enable-new-dtags',
-            '--enable-targets=mips64el-linux-gnuabi64,mips64el-linux-gnuabin32',
-            '--enable-threads'
+            '--enable-targets=mips64el-linux-gnuabi64,mips64el-linux-gnuabin32'
         ],
-        "powerpc-linux-gnu": [
-            '--enable-lto', '--enable-relro', '--enable-threads',
-            '--disable-sim', '--with-pic'
-        ],
-        "riscv64-linux-gnu": [
-            '--enable-lto', '--enable-relro', '--enable-threads',
-            '--disable-sim', '--with-pic'
-        ],
+        "powerpc-linux-gnu":
+        ['--enable-lto', '--enable-relro', '--disable-sim', '--with-pic'],
+        "riscv64-linux-gnu":
+        ['--enable-lto', '--enable-relro', '--disable-sim', '--with-pic'],
         "s390x-linux-gnu": [
             '--enable-lto', '--enable-relro',
-            '--enable-targets=s390-linux-gnu', '--enable-threads', '--with-pic'
+            '--enable-targets=s390-linux-gnu', '--with-pic'
         ],
         "x86_64-linux-gnu": [
             '--enable-lto', '--enable-relro', '--enable-targets=x86_64-pep',
-            '--enable-threads', '--with-pic'
+            '--with-pic'
         ]
     }
     configure_arch_flags['aarch64-linux-gnu'] = configure_arch_flags[

--- a/build-binutils.py
+++ b/build-binutils.py
@@ -148,13 +148,12 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
     :param host_arch: Host architecture to optimize for
     """
     configure = [
-        root_folder.joinpath(utils.current_binutils(),
-                             "configure").as_posix(), 'CC=gcc', 'CXX=g++',
-        '--prefix=%s' % install_folder.as_posix(),
-        '--enable-deterministic-archives', '--enable-plugins', '--quiet',
-        '--disable-gdb', '--disable-werror', '--with-system-zlib',
-        '--enable-threads', '--disable-compressed-debug-sections',
-        '--enable-new-dtags'
+        root_folder.joinpath(utils.current_binutils(), "configure").as_posix(),
+        'CC=gcc', 'CXX=g++', '--disable-compressed-debug-sections',
+        '--disable-gdb', '--disable-werror', '--enable-deterministic-archives',
+        '--enable-new-dtags', '--enable-plugins', '--enable-threads',
+        '--prefix=%s' % install_folder.as_posix(), '--quiet',
+        '--with-system-zlib'
     ]
     if host_arch:
         configure += [
@@ -171,10 +170,10 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
             '--with-sysroot=%s' % install_folder.joinpath(target).as_posix()
         ],
         "powerpc-linux-gnu":
-        ['--enable-lto', '--enable-relro', '--disable-sim', '--with-pic'],
+        ['--disable-sim', '--enable-lto', '--enable-relro', '--with-pic'],
     }
     configure_arch_flags['aarch64-linux-gnu'] = configure_arch_flags[
-        'arm-linux-gnueabi'] + ['--enable-ld=default', '--enable-gold']
+        'arm-linux-gnueabi'] + ['--enable-gold', '--enable-ld=default']
     configure_arch_flags['powerpc64-linux-gnu'] = configure_arch_flags[
         'powerpc-linux-gnu']
     configure_arch_flags['powerpc64le-linux-gnu'] = configure_arch_flags[

--- a/build-binutils.py
+++ b/build-binutils.py
@@ -152,7 +152,7 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
                              "configure").as_posix(), 'CC=gcc', 'CXX=g++',
         '--prefix=%s' % install_folder.as_posix(),
         '--enable-deterministic-archives', '--enable-plugins', '--quiet',
-        '--disable-gdb', '--disable-werror'
+        '--disable-gdb', '--disable-werror', '--with-system-zlib'
     ]
     if host_arch:
         configure += [
@@ -180,22 +180,19 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
         ],
         "powerpc-linux-gnu": [
             '--enable-lto', '--enable-relro', '--enable-threads',
-            '--disable-sim', '--with-pic',
-            '--with-system-zlib'
+            '--disable-sim', '--with-pic'
         ],
         "riscv64-linux-gnu": [
             '--enable-lto', '--enable-relro', '--enable-threads',
-            '--disable-sim', '--with-pic', '--with-system-zlib'
+            '--disable-sim', '--with-pic'
         ],
         "s390x-linux-gnu": [
             '--enable-lto', '--enable-relro',
-            '--enable-targets=s390-linux-gnu', '--enable-threads',
-            '--with-pic', '--with-system-zlib'
+            '--enable-targets=s390-linux-gnu', '--enable-threads', '--with-pic'
         ],
         "x86_64-linux-gnu": [
             '--enable-lto', '--enable-relro', '--enable-targets=x86_64-pep',
-            '--enable-threads', '--with-pic',
-            '--with-system-zlib'
+            '--enable-threads', '--with-pic'
         ]
     }
     configure_arch_flags['aarch64-linux-gnu'] = configure_arch_flags[


### PR DESCRIPTION
While adding support for m68k, I realized that our flags were similar enough for no reason. Clean them up, which makes adding new architectures easier.

This passes my build tests across all of the distributions I test.