### PR TITLE
build-binutils.py: Remove '--with-sysroot' configuration flag

### DIFF
--- a/build-binutils.py
+++ b/build-binutils.py
@@ -166,8 +166,7 @@ def invoke_configure(build_folder, install_folder, root_folder, target,
     configure_arch_flags = {
         "arm-linux-gnueabi": [
             '--disable-multilib', '--disable-nls', '--with-gnu-as',
-            '--with-gnu-ld',
-            '--with-sysroot=%s' % install_folder.joinpath(target).as_posix()
+            '--with-gnu-ld'
         ],
         "powerpc-linux-gnu":
         ['--disable-sim', '--enable-lto', '--enable-relro', '--with-pic'],


### PR DESCRIPTION
This causes issues with arm64 natively on Debian, with both a Raspberry
Pi and Ampere eMAG server. This does not regress x86 based builds in my
testing.