### PR TITLE
build-llvm.py: Build compiler-rt builtins

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -857,7 +857,6 @@ def project_cmake_defines(args, stage):
             defines['COMPILER_RT_BUILD_LIBFUZZER'] = 'OFF'
             # We only use compiler-rt for the sanitizers, disable some extra stuff we don't need
             # Chromium OS also does this: https://crrev.com/c/1629950
-            defines['COMPILER_RT_BUILD_BUILTINS'] = 'OFF'
             defines['COMPILER_RT_BUILD_CRT'] = 'OFF'
             defines['COMPILER_RT_BUILD_XRAY'] = 'OFF'
         # We don't need the sanitizers for the stage 1 bootstrap


### PR DESCRIPTION
Android's kernel/common tree has a patch that forces the use of
compiler-rt for the host tools so the build breaks when using a version
of LLVM built with this script because these are not available.

Link: https://android.googlesource.com/kernel/common/+/f14e5bfb39b776318133e00b8c066ce8a870e9ab