### PR TITLE
kernel/build.sh: Update name of source flag and variable

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -1159,7 +1159,7 @@ def kernel_build_sh(args, config, dirs):
     if config != "defconfig":
         build_sh += ['--%s' % config]
     if dirs.linux_folder:
-        build_sh += ['-s', dirs.linux_folder.as_posix()]
+        build_sh += ['-k', dirs.linux_folder.as_posix()]
     show_command(args, build_sh)
     subprocess.run(build_sh, check=True, cwd=dirs.build_folder.as_posix())
 

--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -23,16 +23,16 @@ function parse_parameters() {
                 shift
                 BUILD_FOLDER=${1}
                 ;;
+            "-k" | "--kernel-src")
+                shift
+                KERNEL_SRC=${1}
+                ;;
             "-p" | "--path-override")
                 shift
                 PATH_OVERRIDE=${1}
                 ;;
             "--pgo")
                 PGO=true
-                ;;
-            "-s" | "--src-folder")
-                shift
-                SRC_FOLDER=${1}
                 ;;
             "-t" | "--targets")
                 shift
@@ -80,9 +80,9 @@ function setup_up_path() {
 }
 
 function setup_krnl_src() {
-    # A kernel folder can be supplied via '-f' for testing the script
-    if [[ -n ${SRC_FOLDER} ]]; then
-        cd "${SRC_FOLDER}" || exit 1
+    # A kernel folder can be supplied via '-k' for testing the script
+    if [[ -n ${KERNEL_SRC} ]]; then
+        cd "${KERNEL_SRC}" || exit 1
     else
         LINUX=linux-5.11.11
         LINUX_TARBALL=${KRNL}/${LINUX}.tar.xz


### PR DESCRIPTION
If a user has SRC_FOLDER defined and exported in their environment, the
script will not work properly. Choose a slighly more specific name to
avoid this and adjust the flag to match.