### PR TITLE
build-llvm.py: Fix handling of '--projects'

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -843,11 +843,12 @@ def project_cmake_defines(args, stage):
             projects = "clang;lld"
             if args.pgo:
                 projects += ';compiler-rt'
+        elif instrumented_stage(args, stage):
+            projects = "clang;lld"
+        elif args.projects:
+            projects = args.projects
         else:
-            if instrumented_stage(args, stage):
-                projects = "clang;lld"
-            else:
-                projects = "clang;compiler-rt;lld;polly"
+            projects = "clang;compiler-rt;lld;polly"
 
     defines['LLVM_ENABLE_PROJECTS'] = projects
 


### PR DESCRIPTION
Turns out I broke this in commit 6d2853a ("build-llvm.py: Add
'--full-toolchain'") because I never handled the case of '--projects'
being specified. Make the if statements a little simpler and handle
'--projects' again.