### PR TITLE
README.md: Clarify that latest version of distribution should be used whenever possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are times where a tip of tree LLVM build will have some issue fixed and it
 
 ## Getting started
 
-These scripts have been tested in a Docker image of the following distributions, with the following packages installed:
+These scripts have been tested in a Docker image of the following distributions with the following packages installed. LLVM has [minimum host tool version requirements](https://llvm.org/docs/GettingStarted.html#software) so the latest stable version of the chosen distribution should be used whenever possible to ensure recent versions of the tools are used. Build errors from within LLVM are expected if the tool version is not recent enough, in which case it will need to be built from source or installed through other means.
 
 * ### Debian/Ubuntu
 
@@ -34,6 +34,7 @@ These scripts have been tested in a Docker image of the following distributions,
               git \
               libelf-dev \
               libssl-dev \
+              lld \
               make \
               ninja-build \
               python3 \
@@ -42,8 +43,6 @@ These scripts have been tested in a Docker image of the following distributions,
               xz-utils \
               zlib1g-dev
   ```
-
-  On Debian Buster or Ubuntu Bionic/Cosmic/Disco, `apt install lld` should be added as well for faster compiles.
 
 * ### Fedora
 


### PR DESCRIPTION
LLVM has certain minimum version requirements for cmake and the C
compiler (gcc/clang) and the build will error out if the host version
does not satisfy those requirements. This is expected and it is the
user's responsibility to make sure that their environment satisfies
those requirements according to LLVM's documentation.

Add a note that says the latest version of a distribution (in
particular, Debian and Ubuntu) should be used whenever possible so that
there are not unexpected build errors.

Remove the note about ld.lld for Debian and Ubuntu while we are here, it
is available as the "lld" package on Buster and Focal, which are the
latest versions of these distributions respectively.

Closes: https://github.com/ClangBuiltLinux/tc-build/issues/163