### PR TITLE
.github/CODEOWNERS: Adjust file globs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-*.py @msfjarvis @nathanchance @nickdesaulniers @stephenhines
-*.sh @msfjarvis @nathanchance @nickdesaulniers @stephenhines
+* @msfjarvis @nathanchance @nickdesaulniers @stephenhines


### PR DESCRIPTION
Right now, if someone opens a pull request that only touches non-Python
and non-shell files, no review is automatically requested, which could
result in things falling through the cracks.