### PR TITLE
kernel: build.sh: Use wget instead of curl to get kernel tars

### DIFF
--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -105,7 +105,7 @@ function setup_krnl_src() {
 
         # If we don't have the source tarball, download and verify it
         if [[ ! -f ${LINUX_TARBALL} ]]; then
-            curl -LSso "${LINUX_TARBALL}" https://cdn.kernel.org/pub/linux/kernel/v5.x/"${LINUX_TARBALL##*/}"
+            wget "${LINUX_TARBALL}" https://cdn.kernel.org/pub/linux/kernel/v5.x/"${LINUX_TARBALL##*/}"
 
             (
                 cd "${LINUX_TARBALL%/*}" || exit 1


### PR DESCRIPTION
sometimes i ran into this error in some distro(s) when the kernel build script was extracting the kernel tar file:

> xz: (stdin): File format not recognized
> tar: Child returned status 1
> tar: Error is not recoverable: exiting now

after some checking, i found that when the file is downloaded using curl, the file type is shown as a website html file:

$ file linux-5.14.tar.xz
> linux-5.14.tar.xz: HTML document, ASCII text, with very long lines (670)

to fix this, we can use wget instead of curl, after using wget:

$ file linux-5.14.tar.xz
> linux-5.14.tar.xz: XZ compressed data, checksum CRC64