### PR TITLE
Increase number of vp counters per site with PGO

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -956,6 +956,7 @@ def stage_specific_cmake_defines(args, dirs, stage):
         if instrumented_stage(args, stage):
             defines['LLVM_BUILD_INSTRUMENTED'] = 'IR'
             defines['LLVM_BUILD_RUNTIME'] = 'OFF'
+            defines['LLVM_VP_COUNTERS_PER_SITE'] = '6'
 
         # If we are at the final stage, use PGO/Thin LTO if requested
         if stage == get_final_stage(args):


### PR DESCRIPTION
When doing a PGO kernel-defconfig build, the following warning pops up:

`Unable to track new values: Running out of static counters. Consider using option -mllvm -vp-counters-per-site=<n> to allocate more value profile counters at compile time.`

Use the cmake define `LLVM_VP_COUNTERS_PER_SITE` to increase counters to 6 when running the instrumentation stage.
This is an arbitrary value, a lower number may be sufficient.