### PR TITLE
Improvements around non-x86_64 native use

### DIFF
--- a/clang-version.sh
+++ b/clang-version.sh
@@ -1,19 +1,26 @@
 #!/bin/sh
+# shellcheck disable=SC2046,SC2086
 # SPDX-License-Identifier: GPL-2.0
 #
-# clang-version clang-command
-#
-# Print the compiler version of `clang-command' in a 5 or 6-digit form
-# such as `50001' for clang-5.0.1 etc.
+# Print clang's version in a 5 or 6-digit form.
 
-compiler="$*"
+set -e
 
-if ! ($compiler --version | grep -q clang); then
-    echo 0
-    exit 1
-fi
+# Print the compiler name and some version components.
+get_compiler_info() {
+    cat <<-EOF | "$@" -E -P -x c - 2>/dev/null
+	__clang_major__  __clang_minor__  __clang_patchlevel__
+	EOF
+}
 
-MAJOR=$(echo __clang_major__ | $compiler -E -x c - | tail -n 1)
-MINOR=$(echo __clang_minor__ | $compiler -E -x c - | tail -n 1)
-PATCHLEVEL=$(echo __clang_patchlevel__ | $compiler -E -x c - | tail -n 1)
-printf "%d%02d%02d\\n" "$MAJOR" "$MINOR" "$PATCHLEVEL"
+# Convert the version string x.y.z to a canonical 5 or 6-digit form.
+get_canonical_version() {
+    IFS=.
+    set -- $1
+    echo $((10000 * $1 + 100 * $2 + $3))
+}
+
+# $@ instead of $1 because multiple words might be given, e.g. CC="ccache gcc".
+set -- $(get_compiler_info "$@")
+
+get_canonical_version $1.$2.$3

--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -196,10 +196,11 @@ function print_tc_info() {
     header "Toolchain information"
     clang --version
     for PREFIX in "${TARGETS[@]}"; do
+        can_use_llvm_ias "$PREFIX" && continue
+
         echo
         case ${PREFIX} in
             x86_64-linux-gnu) as --version ;;
-            hexagon-linux-gnu) ;;
             *) "${PREFIX}"-as --version ;;
         esac
     done

--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -306,6 +306,7 @@ function build_kernels() {
                 ;;
             "x86_64-linux-gnu")
                 time "${MAKE[@]}" \
+                    ARCH=x86_64 \
                     distclean "${CONFIG_TARGET}" all || exit ${?}
                 ;;
         esac

--- a/kernel/build.sh
+++ b/kernel/build.sh
@@ -215,8 +215,6 @@ function clang_supports_host_target() {
 }
 
 function build_kernels() {
-    # SC2191: The = here is literal. To assign by index, use ( [index]=value ) with no spaces. To keep as literal, quote it.
-    # shellcheck disable=SC2191
     MAKE=(make -skj"$(nproc)" KCFLAGS=-Wno-error LLVM=1 O=out)
 
     clang_supports_host_target || MAKE+=(HOSTCC=gcc HOSTCXX=g++)


### PR DESCRIPTION
This pull request removes all assumptions that these scripts are being run on x86_64 hardware. It has been verified on both AArch64 and x86_64 hardware. See the individual commits for the improvements.