### PR TITLE
build-llvm.py: Dynamically link the instrumented stage against libLLVM

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -958,6 +958,10 @@ def stage_specific_cmake_defines(args, dirs, stage):
         if instrumented_stage(args, stage):
             defines['LLVM_BUILD_INSTRUMENTED'] = 'IR'
             defines['LLVM_BUILD_RUNTIME'] = 'OFF'
+            # The next two defines is needed to avoid thousands of warnings
+            # along the lines of:
+            # "Unable to track new values: Running out of static counters."
+            defines['LLVM_LINK_LLVM_DYLIB'] = 'ON'
             defines['LLVM_VP_COUNTERS_PER_SITE'] = '6'
 
         # If we are at the final stage, use PGO/Thin LTO if requested


### PR DESCRIPTION
Recently, I have been seeing thousands of warnings along the lines of:

```
LLVM Profile Warning: Unable to track new values: Running out of static counters.  Consider using option -mllvm -vp-counters-per-site=<n> to allocate more value profile counters at compile time.
LLVM Profile Warning: Unable to track new values: Running out of static counters.  Consider using option -mllvm -vp-counters-per-site=<n> to allocate more value profile counters at compile time.
LLVM Profile Warning: Unable to track new values: Running out of static counters.  Consider using option -mllvm -vp-counters-per-site=<n> to allocate more value profile counters at compile time.
```

I am not sure if this is due to a recent change in LLVM or because I do
not usually look at the output of `build-llvm.py` when running a PGO
build.

LLVM commit a5f5612263ca ("[PGO] Adjust -vp-counters-per-site under
dynamic linking.") addressed this when dynamically linking against
`libLLVM` but not static linking due to size concerns.

tc-build commit 170c5cf ("Increase number of vp counters per site")
added the cmake variable that the above LLVM commit added but we do not
dynamically link against `libLLVM` so it does not actually do anything,
which was noted during the review as intentional, as users can add
`--defines LLVM_LINK_LLVM_DYLIB=ON` themselves.

To resolve the above warnings, just turn on dynamically linking against
`libLLVM` for the instrumented stage. This is not done for all stages, as
dynamically linking against libLLVM will be objectively slower than
statically linking, even with the optimizations added in LLVM commit
3bf1acab5b45 ("[CMake][ELF] Add -fno-semantic-interposition and
-Bsymbolic-functions"). This should not drastically impact the speed of
the instrumented stage in my testing, as the instrumentation itself is
already quite slow.

Link: https://reviews.llvm.org/D92669
Link: https://lore.kernel.org/CAKwvOdk0nxxUATg2jEKgx4HutXCMXcW92SX3DT+uCTgqBwQHBg@mail.gmail.com/
