### PR TITLE
tc-build: Initial BOLT support

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -98,3 +98,12 @@ def print_error(string):
     """
     # Use bold red for error
     print("\033[01;31m%s\n\033[0m" % string)
+
+
+def print_warning(string):
+    """
+    Prints a error in bold yellow
+    :param string: String to print
+    """
+    # Use bold yellow for error
+    print("\033[01;33m%s\n\033[0m" % string)


### PR DESCRIPTION
From bolt/README.md:

"BOLT is a post-link optimizer developed to speed up large applications.
It achieves the improvements by optimizing application's code layout
based on execution profile gathered by sampling profiler, such as Linux
perf tool."

Wire up support for BOLT into tc-build by generating a profile through
perf if it is support or BOLT's instrumentation if not. The profile is
generated by building a kernel with the final clang binary. The kernel
will either be the host architecture's defconfig if it is supported in
the lists of targets or the first target's defconfig.