### PR TITLE
build-llvm.py: Add a note about LLVM commit 7d7771f34d14 for BOLT

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -136,6 +136,13 @@ def parse_parameters(root_folder):
                         4. The clang binary will be optimized with BOLT using the profile generated above. This can
                            take some time.
 
+                           NOTE #3: Versions of BOLT without commit 7d7771f34d14 ("[BOLT] Compact legacy profiles")
+                                    will use significantly more memory during this stage if instrumentation is used
+                                    because the merged profile is not as slim as it could be. Either upgrade to a
+                                    version of LLVM that contains that change or pick it yourself, switch to perf if
+                                    your machine supports it, upgrade the amount of memory you have (if possible),
+                                    or run build-llvm.py without '--bolt'.
+
                         """),
                         action="store_true")
     opt_options.add_argument("--build-stage1-only",


### PR DESCRIPTION
LLVM commit 7d7771f34d14 ("[BOLT] Compact legacy profiles") makes the
merged profiles much smaller, which allows less powerful machines to do
BOLT. Add a note about it to the `--bolt` help text so that users are
aware that performing BOLT without that change will require much more
memory.

Closes: https://github.com/ClangBuiltLinux/tc-build/issues/188
Link: https://github.com/llvm/llvm-project/commit/7d7771f34d14e0108adf02a6fd0b33943afae3da
