### PR TITLE
build-llvm.py: Fix 'LLVM source location does not exist' error message

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -1604,7 +1604,7 @@ def main():
             llvm_folder = root_folder.joinpath(llvm_folder)
         if not llvm_folder.exists():
             utils.print_error("\nSupplied LLVM source (%s) does not exist!" %
-                              linux_folder.as_posix())
+                              llvm_folder.as_posix())
             exit(1)
     else:
         llvm_folder = root_folder.joinpath("llvm-project")


### PR DESCRIPTION
The wrong folder is being used, which results in:

```
Traceback (most recent call last):
  File ".../build-llvm.py", line 1620, in <module>
    main()
  File ".../build-llvm.py", line 1607, in main
    linux_folder.as_posix())
AttributeError: 'NoneType' object has no attribute 'as_posix'
```
