### PR TITLE
Allow user to control binutils source folder location and installation

### DIFF
--- a/build-binutils.py
+++ b/build-binutils.py
@@ -3,7 +3,6 @@
 
 import argparse
 import multiprocessing
-import os
 import pathlib
 import platform
 import shutil
@@ -60,8 +59,8 @@ def parse_parameters(root_folder):
                         or relative path.
                         """,
                         type=str,
-                        default=os.path.join(root_folder.as_posix(), "build",
-                                             "binutils"))
+                        default=root_folder.joinpath("build",
+                                                     "binutils").as_posix())
     parser.add_argument("-I",
                         "--install-folder",
                         help="""
@@ -70,8 +69,7 @@ def parse_parameters(root_folder):
                         it to this parameter. This can either be an absolute or relative path.
                         """,
                         type=str,
-                        default=os.path.join(root_folder.as_posix(),
-                                             "install"))
+                        default=root_folder.joinpath("install").as_posix())
     parser.add_argument("-t",
                         "--targets",
                         help="""


### PR DESCRIPTION
The first patch is a small clean up that I noticed.

The second patch allows the user to specify a local binutils source, which is useful for testing master.

The third patch allows the user to skip installing binutils after building, which is useful for doing exclusively build testing, such as during a bisect of a build breakage.
