### PR TITLE
tc-build: Python updates

### DIFF
--- a/build-binutils.py
+++ b/build-binutils.py
@@ -167,11 +167,11 @@ def invoke_configure(binutils_folder, build_folder, install_folder, target,
         '--quiet', '--with-system-zlib'
     ]
     if install_folder:
-        configure += ['--prefix=%s' % install_folder.as_posix()]
+        configure += [f'--prefix={install_folder.as_posix()}']
     if host_arch:
         configure += [
-            'CFLAGS=-O2 -march=%s -mtune=%s' % (host_arch, host_arch),
-            'CXXFLAGS=-O2 -march=%s -mtune=%s' % (host_arch, host_arch)
+            f'CFLAGS=-O2 -march={host_arch} -mtune={host_arch}',
+            f'CXXFLAGS=-O2 -march={host_arch} -mtune={host_arch}'
         ]
     else:
         configure += ['CFLAGS=-O2', 'CXXFLAGS=-O2']
@@ -198,9 +198,8 @@ def invoke_configure(binutils_folder, build_folder, install_folder, target,
         'powerpc-linux-gnu'] + ['--enable-targets=x86_64-pep']
 
     for endian in ["", "el"]:
-        configure_arch_flags['mips%s-linux-gnu' % (endian)] = [
-            '--enable-targets=mips64%s-linux-gnuabi64,mips64%s-linux-gnuabin32'
-            % (endian, endian)
+        configure_arch_flags[f'mips{endian}-linux-gnu'] = [
+            f'--enable-targets=mips64{endian}-linux-gnuabi64,mips64{endian}-linux-gnuabin32'
         ]
 
     configure += configure_arch_flags.get(target, [])
@@ -208,9 +207,9 @@ def invoke_configure(binutils_folder, build_folder, install_folder, target,
     # If the current machine is not the target, add the prefix to indicate
     # that it is a cross compiler
     if not host_is_target(target):
-        configure += ['--program-prefix=%s-' % target, '--target=%s' % target]
+        configure += [f'--program-prefix={target}-', f'--target={target}']
 
-    utils.print_header("Building %s binutils" % target)
+    utils.print_header(f"Building {target} binutils")
     subprocess.run(configure, check=True, cwd=build_folder.as_posix())
 
 
@@ -229,7 +228,7 @@ def invoke_make(build_folder, install_folder, target):
     subprocess.run(make, check=True, cwd=build_folder.as_posix())
     if install_folder:
         subprocess.run(make +
-                       ['prefix=%s' % install_folder.as_posix(), 'install'],
+                       [f'prefix={install_folder.as_posix()}', 'install'],
                        check=True,
                        cwd=build_folder.as_posix())
         with install_folder.joinpath(".gitignore").open("w") as gitignore:

--- a/build-binutils.py
+++ b/build-binutils.py
@@ -67,8 +67,7 @@ def parse_parameters(root_folder):
                         or relative path.
                         """,
                         type=str,
-                        default=root_folder.joinpath("build",
-                                                     "binutils").as_posix())
+                        default=root_folder.joinpath("build", "binutils"))
     parser.add_argument("-I",
                         "--install-folder",
                         help="""
@@ -77,7 +76,7 @@ def parse_parameters(root_folder):
                         it to this parameter. This can either be an absolute or relative path.
                         """,
                         type=str,
-                        default=root_folder.joinpath("install").as_posix())
+                        default=root_folder.joinpath("install"))
     parser.add_argument("-s",
                         "--skip-install",
                         help="""
@@ -145,7 +144,7 @@ def cleanup(build_folder):
     :param build_folder: Build directory
     """
     if build_folder.is_dir():
-        shutil.rmtree(build_folder.as_posix())
+        shutil.rmtree(build_folder)
     build_folder.mkdir(parents=True, exist_ok=True)
 
 
@@ -160,14 +159,14 @@ def invoke_configure(binutils_folder, build_folder, install_folder, target,
     :param host_arch: Host architecture to optimize for
     """
     configure = [
-        binutils_folder.joinpath("configure").as_posix(), 'CC=gcc', 'CXX=g++',
+        binutils_folder.joinpath("configure"), 'CC=gcc', 'CXX=g++',
         '--disable-compressed-debug-sections', '--disable-gdb',
         '--disable-werror', '--enable-deterministic-archives',
         '--enable-new-dtags', '--enable-plugins', '--enable-threads',
         '--quiet', '--with-system-zlib'
     ]
     if install_folder:
-        configure += [f'--prefix={install_folder.as_posix()}']
+        configure += [f'--prefix={install_folder}']
     if host_arch:
         configure += [
             f'CFLAGS=-O2 -march={host_arch} -mtune={host_arch}',
@@ -210,7 +209,7 @@ def invoke_configure(binutils_folder, build_folder, install_folder, target,
         configure += [f'--program-prefix={target}-', f'--target={target}']
 
     utils.print_header(f"Building {target} binutils")
-    subprocess.run(configure, check=True, cwd=build_folder.as_posix())
+    subprocess.run(configure, check=True, cwd=build_folder)
 
 
 def invoke_make(build_folder, install_folder, target):
@@ -222,15 +221,12 @@ def invoke_make(build_folder, install_folder, target):
     """
     make = ['make', '-s', '-j' + str(multiprocessing.cpu_count()), 'V=0']
     if host_is_target(target):
-        subprocess.run(make + ['configure-host'],
-                       check=True,
-                       cwd=build_folder.as_posix())
-    subprocess.run(make, check=True, cwd=build_folder.as_posix())
+        subprocess.run(make + ['configure-host'], check=True, cwd=build_folder)
+    subprocess.run(make, check=True, cwd=build_folder)
     if install_folder:
-        subprocess.run(make +
-                       [f'prefix={install_folder.as_posix()}', 'install'],
+        subprocess.run(make + [f'prefix={install_folder}', 'install'],
                        check=True,
-                       cwd=build_folder.as_posix())
+                       cwd=build_folder)
         with install_folder.joinpath(".gitignore").open("w") as gitignore:
             gitignore.write("*")
 

--- a/utils.py
+++ b/utils.py
@@ -37,15 +37,14 @@ def download_binutils(folder):
         # Remove any previous copies of binutils
         for entity in folder.glob('binutils-*'):
             if entity.is_dir():
-                shutil.rmtree(entity.as_posix())
+                shutil.rmtree(entity)
             else:
                 entity.unlink()
 
         # Download the tarball
         binutils_tarball = folder.joinpath(binutils + ".tar.xz")
         subprocess.run([
-            "curl", "-LSs", "-o",
-            binutils_tarball.as_posix(),
+            "curl", "-LSs", "-o", binutils_tarball,
             "https://ftp.gnu.org/gnu/binutils/" + binutils_tarball.name
         ],
                        check=True)
@@ -53,7 +52,7 @@ def download_binutils(folder):
         # Extract the tarball then remove it
         subprocess.run(["tar", "-xJf", binutils_tarball.name],
                        check=True,
-                       cwd=folder.as_posix())
+                       cwd=folder)
         create_gitignore(binutils_folder)
         binutils_tarball.unlink()
 

--- a/utils.py
+++ b/utils.py
@@ -90,7 +90,7 @@ def print_header(string):
     print("\033[01;36m")
     for x in range(0, len(string) + 6):
         print("=", end="")
-    print("\n== %s ==" % string)
+    print(f"\n== {string} ==")
     for x in range(0, len(string) + 6):
         print("=", end="")
     # \033[0m resets the color back to the user's default
@@ -104,7 +104,7 @@ def print_error(string):
     :param string: String to print
     """
     # Use bold red for error
-    print("\033[01;31m%s\n\033[0m" % string, flush=True)
+    print(f"\033[01;31m{string}\n\033[0m", flush=True)
 
 
 def print_warning(string):
@@ -113,4 +113,4 @@ def print_warning(string):
     :param string: String to print
     """
     # Use bold yellow for error
-    print("\033[01;33m%s\n\033[0m" % string, flush=True)
+    print(f"\033[01;33m{string}\n\033[0m", flush=True)


### PR DESCRIPTION
The commit messages should be self explanatory but this PR updates tc-build to use f-strings (preferred in Python 3.6+) and eliminates as_posix() calls on path objects (possible after Python 3.6+), which cleans up the code a bit.
