### PR TITLE
tc-build: Stop building the gold plugin

### DIFF
--- a/build-binutils.py
+++ b/build-binutils.py
@@ -3,12 +3,69 @@
 # Description: Builds a standalone copy of binutils
 
 import argparse
+import hashlib
 import multiprocessing
 import pathlib
 import platform
 import shutil
 import subprocess
 import utils
+
+
+def current_binutils():
+    """
+    Simple getter for current stable binutils release
+    :return: The current stable release of binutils
+    """
+    return "binutils-2.39"
+
+
+def download_binutils(folder):
+    """
+    Downloads the latest stable version of binutils
+    :param folder: Directory to download binutils to
+    """
+    binutils = current_binutils()
+    binutils_folder = folder.joinpath(binutils)
+    if not binutils_folder.is_dir():
+        # Remove any previous copies of binutils
+        for entity in folder.glob('binutils-*'):
+            if entity.is_dir():
+                shutil.rmtree(entity)
+            else:
+                entity.unlink()
+
+        # Download the tarball
+        binutils_tarball = folder.joinpath(binutils + ".tar.xz")
+        curl_cmd = [
+            "curl", "-LSs", "-o", binutils_tarball,
+            "https://ftp.gnu.org/gnu/binutils/" + binutils_tarball.name
+        ]
+        subprocess.run(curl_cmd, check=True)
+        verify_binutils_checksum(binutils_tarball)
+        # Extract the tarball then remove it
+        subprocess.run(["tar", "-xJf", binutils_tarball.name],
+                       check=True,
+                       cwd=folder)
+        utils.create_gitignore(binutils_folder)
+        binutils_tarball.unlink()
+
+
+def verify_binutils_checksum(file_to_check):
+    # Check the SHA512 checksum of the downloaded file with a known good one
+    # The sha512.sum file from <sourceware.org> ships the SHA512 checksums
+    # Link: https://sourceware.org/pub/binutils/releases/sha512.sum
+    file_hash = hashlib.sha512()
+    with file_to_check.open("rb") as file:
+        while True:
+            data = file.read(131072)
+            if not data:
+                break
+            file_hash.update(data)
+    good_hash = "68e038f339a8c21faa19a57bbc447a51c817f47c2e06d740847c6e9cc3396c025d35d5369fa8c3f8b70414757c89f0e577939ddc0d70f283182504920f53b0a3"
+    if file_hash.hexdigest() != good_hash:
+        raise RuntimeError(
+            "binutils: SHA512 checksum does not match known good one!")
 
 
 def host_arch_target():
@@ -260,8 +317,8 @@ def main():
         if not binutils_folder.is_absolute():
             binutils_folder = root_folder.joinpath(binutils_folder)
     else:
-        binutils_folder = root_folder.joinpath(utils.current_binutils())
-        utils.download_binutils(root_folder)
+        binutils_folder = root_folder.joinpath(current_binutils())
+        download_binutils(root_folder)
 
     build_folder = pathlib.Path(args.build_folder)
     if not build_folder.is_absolute():

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -620,10 +620,9 @@ def ref_exists(repo, ref):
     return True
 
 
-def fetch_llvm_binutils(root_folder, llvm_folder, update, shallow, ref):
+def fetch_llvm(llvm_folder, update, shallow, ref):
     """
-    Download llvm and binutils or update them if they exist
-    :param root_folder: Working directory
+    Download llvm if it does not exist, update it if it does
     :param llvm_folder: llvm-project repo directory
     :param update: Boolean indicating whether sources need to be updated or not
     :param ref: The ref to checkout the monorepo to
@@ -689,12 +688,6 @@ def fetch_llvm_binutils(root_folder, llvm_folder, update, shallow, ref):
         ]
         subprocess.run(git_clone_cmd, check=True)
         subprocess.run(["git", "checkout", ref], check=True, cwd=llvm_folder)
-
-    # One might wonder why we are downloading binutils in an LLVM build script :)
-    # We need it for the LLVMgold plugin, which can be used for LTO with ld.gold,
-    # which at the time of writing this, is how the Google Pixel 3 kernel is built
-    # and linked.
-    utils.download_binutils(root_folder)
 
 
 def cleanup(build_folder, incremental):
@@ -1072,11 +1065,6 @@ def stage_specific_cmake_defines(args, dirs, stage):
         for key in keys:
             if key not in str(args.defines):
                 defines[key] = ''
-
-        # For LLVMgold.so, which is used for LTO with ld.gold
-        defines['LLVM_BINUTILS_INCDIR'] = dirs.root_folder.joinpath(
-            utils.current_binutils(), "include")
-        defines['LLVM_ENABLE_PLUGINS'] = 'ON'
 
     return defines
 
@@ -1620,8 +1608,7 @@ def main():
         ref = args.branch
 
     if not args.llvm_folder:
-        fetch_llvm_binutils(root_folder, llvm_folder, not args.no_update,
-                            args.shallow_clone, ref)
+        fetch_llvm(llvm_folder, not args.no_update, args.shallow_clone, ref)
     cleanup(build_folder, args.incremental)
     dirs = Directories(build_folder, install_folder, linux_folder, llvm_folder,
                        root_folder)

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 # Description: Common helper functions
 
-import hashlib
-import shutil
 import sys
-import subprocess
 
 
 def create_gitignore(folder):
@@ -15,62 +12,6 @@ def create_gitignore(folder):
     """
     with folder.joinpath(".gitignore").open("w") as gitignore:
         gitignore.write("*")
-
-
-def current_binutils():
-    """
-    Simple getter for current stable binutils release
-    :return: The current stable release of binutils
-    """
-    return "binutils-2.39"
-
-
-def download_binutils(folder):
-    """
-    Downloads the latest stable version of binutils
-    :param folder: Directory to download binutils to
-    """
-    binutils = current_binutils()
-    binutils_folder = folder.joinpath(binutils)
-    if not binutils_folder.is_dir():
-        # Remove any previous copies of binutils
-        for entity in folder.glob('binutils-*'):
-            if entity.is_dir():
-                shutil.rmtree(entity)
-            else:
-                entity.unlink()
-
-        # Download the tarball
-        binutils_tarball = folder.joinpath(binutils + ".tar.xz")
-        curl_cmd = [
-            "curl", "-LSs", "-o", binutils_tarball,
-            "https://ftp.gnu.org/gnu/binutils/" + binutils_tarball.name
-        ]
-        subprocess.run(curl_cmd, check=True)
-        verify_binutils_checksum(binutils_tarball)
-        # Extract the tarball then remove it
-        subprocess.run(["tar", "-xJf", binutils_tarball.name],
-                       check=True,
-                       cwd=folder)
-        create_gitignore(binutils_folder)
-        binutils_tarball.unlink()
-
-
-def verify_binutils_checksum(file_to_check):
-    # Check the SHA512 checksum of the downloaded file with a known good one
-    # The sha512.sum file from <sourceware.org> ships the SHA512 checksums
-    # Link: https://sourceware.org/pub/binutils/releases/sha512.sum
-    file_hash = hashlib.sha512()
-    with file_to_check.open("rb") as file:
-        while True:
-            data = file.read(131072)
-            if not data:
-                break
-            file_hash.update(data)
-    good_hash = "68e038f339a8c21faa19a57bbc447a51c817f47c2e06d740847c6e9cc3396c025d35d5369fa8c3f8b70414757c89f0e577939ddc0d70f283182504920f53b0a3"
-    if file_hash.hexdigest() != good_hash:
-        raise RuntimeError(
-            "binutils: SHA512 checksum does not match known good one!")
 
 
 def flush_std_err_out():


### PR DESCRIPTION
The only reason that we built the gold plugin in the first place was to
support LTO on the Pixel 3, which used ld.gold instead of ld.lld, unlike
Android 4.14+ and mainline's LTO implementation.

The Pixel 3 has been EOL for several months now, so rip out all the gold
plugin enablement. With that, all the binutils functions in utils can be
moved into build-binutils.py directly, as build-llvm.py does not need to
know about binutils anymore.

Cc @kees, in lieu of #211.
