### PR TITLE
Add support for LoongArch

### DIFF
--- a/build-binutils.py
+++ b/build-binutils.py
@@ -91,10 +91,11 @@ if args.build_folder:
 else:
     build_folder = Path(tc_build_folder, 'build/binutils')
 
+default_targets = bsm.default_targets()
 if args.targets:
-    targets = bsm.default_targets() if 'all' in args.targets else set(args.targets)
+    targets = default_targets if 'all' in args.targets else set(args.targets)
 else:
-    targets = bsm.default_targets()
+    targets = default_targets
 
 targets_to_builder = {
     'arm': tc_build.binutils.ArmBinutilsBuilder,
@@ -108,6 +109,8 @@ targets_to_builder = {
     's390x': tc_build.binutils.S390XBinutilsBuilder,
     'x86_64': tc_build.binutils.X8664BinutilsBuilder,
 }
+if 'loongarch64' in default_targets:
+    targets_to_builder['loongarch64'] = tc_build.binutils.LoongArchBinutilsBuilder
 for item in targets:
     target = item.split('-', maxsplit=1)[0]
     if target in targets_to_builder:

--- a/tc_build/binutils.py
+++ b/tc_build/binutils.py
@@ -119,6 +119,15 @@ class AArch64BinutilsBuilder(NoMultilibBinutilsBuilder):
         self.target = 'aarch64-linux-gnu'
 
 
+class LoongArchBinutilsBuilder(StandardBinutilsBuilder):
+
+    def __init__(self):
+        super().__init__()
+
+        self.native_arch = 'loongarch64'
+        self.target = 'loongarch64-linux-gnu'
+
+
 class MipsBinutilsBuilder(StandardBinutilsBuilder):
 
     def __init__(self, endian_suffix=''):
@@ -197,7 +206,7 @@ class X8664BinutilsBuilder(StandardBinutilsBuilder):
 class BinutilsSourceManager(SourceManager):
 
     def default_targets(self):
-        return [
+        targets = [
             'aarch64',
             'arm',
             'mips',
@@ -209,6 +218,9 @@ class BinutilsSourceManager(SourceManager):
             's390x',
             'x86_64',
         ]
+        if Path(self.location, 'gas/config/tc-loongarch.c').exists():
+            targets.append('loongarch64')
+        return targets
 
     def prepare(self):
         if not self.location:


### PR DESCRIPTION
This pull request adds support for targeting LoongArch, as it may soon be possible to build the LoongArch Linux kernel with clang:

https://github.com/ClangBuiltLinux/linux/issues/1787

The first two patches just clean up a couple things I noticed while writing this series.

The third patch adds support for validating the targets that the user passes; this is largely tangential to this series but `get_all_targets()` is needed for checking if LoongArch can be enabled in LLVM and it is a logical extension to validate the user's input as well.

Finally, the last three patches wire up LoongArch into `build-binutils.py`, `build-llvm.py`, and `kernel/build.sh` (as a no-op for now).

If there are any questions or comments, please let me know.
