### PR TITLE
build-llvm.py: Fix setting LD fails due to inverted test-check

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -451,7 +451,7 @@ def linker_test(cc, ld):
     Test to see if the supplied ld value will work with cc -fuse=ld
     :param cc: A working C compiler to compile the test program
     :param ld: A linker to test -fuse=ld against
-    :return: False if the linker supports -fuse=ld, True otherwise
+    :return: 0 if the linker supports -fuse=ld, 1 otherwise
     """
     cc_cmd = [cc, f'-fuse-ld={ld}', '-o', '/dev/null', '-x', 'c', '-']
 

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -566,7 +566,7 @@ def check_cc_ld_variables(root_folder):
         # and we're using gcc, try to use gold
         else:
             ld = "gold"
-            if linker_test(cc, ld):
+            if not linker_test(cc, ld):
                 ld = None
 
     # Print what binaries we are using to compile/link with so the user can

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -462,9 +462,9 @@ def linker_test(cc, ld):
                        input='int main() { return 0; }',
                        text=True)
     except subprocess.CalledProcessError:
-        return False
+        return True
 
-    return True
+    return False
 
 
 def versioned_binaries(binary_name):

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -541,7 +541,7 @@ def check_cc_ld_variables(root_folder):
         ld = os.environ['LD']
         if "clang" in cc.stem and clang_version(cc, root_folder) >= 30900:
             ld = shutil.which(ld)
-        if linker_test(cc, ld):
+        if not linker_test(cc, ld):
             print(
                 f"LD won't work with {cc}, saving you from yourself by ignoring LD value",
                 flush=True)

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -451,7 +451,7 @@ def linker_test(cc, ld):
     Test to see if the supplied ld value will work with cc -fuse=ld
     :param cc: A working C compiler to compile the test program
     :param ld: A linker to test -fuse=ld against
-    :return: 0 if the linker supports -fuse=ld, 1 otherwise
+    :return: False if the linker supports -fuse=ld, True otherwise
     """
     cc_cmd = [cc, f'-fuse-ld={ld}', '-o', '/dev/null', '-x', 'c', '-']
 

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -462,9 +462,9 @@ def linker_test(cc, ld):
                        input='int main() { return 0; }',
                        text=True)
     except subprocess.CalledProcessError:
-        return True
+        return False
 
-    return False
+    return True
 
 
 def versioned_binaries(binary_name):


### PR DESCRIPTION
When I set `LD` to any legit linker, for example `lld` or `gold`, it prints that it won't work but an incorrect one will go and fail during compilation.