### PR TITLE
build-llvm.py: Switch to dict() over dictionary comprehension

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -518,7 +518,7 @@ if args.vendor_string:
     common_cmake_defines['CLANG_VENDOR'] = args.vendor_string
     common_cmake_defines['LLD_VENDOR'] = args.vendor_string
 if args.defines:
-    defines = {k: v for define in args.defines for k, v in define.split('=', 1)}
+    defines = dict(define.split('=', 1) for define in args.defines)
     common_cmake_defines.update(defines)
 
 # Build bootstrap compiler if user did not request a single stage build


### PR DESCRIPTION
Something is going wrong with the comprehension, as there is a
ValueError when unpacking the define (which makes little sense):

```
Traceback (most recent call last):
  File ".../tc-build/./build-llvm.py", line 521, in <module>
    defines = {k: v for define in args.defines for1 k, v in define.split('=', 1)}
  File ".../tc-build/./build-llvm.py", line 521, in <dictcomp>
    defines = {k: v for define in args.defines for k, v in define.split('=', 1)}
ValueError: too many values to unpack (expected 2)
```

This can be worked around by just using the `dict()` constructor, which is
simpler to read anyways.
