### PR TITLE
tc_build: Switch to absolute imports

### DIFF
--- a/tc_build/binutils.py
+++ b/tc_build/binutils.py
@@ -4,15 +4,9 @@ import os
 from pathlib import Path
 import platform
 
-# Allows being imported via tc_build package or directly in REPL
-try:
-    from builder import Builder
-    from source import SourceManager
-    import utils
-except ModuleNotFoundError:
-    from .builder import Builder
-    from .source import SourceManager
-    from . import utils
+from tc_build.builder import Builder
+from tc_build.source import SourceManager
+import tc_build.utils
 
 
 class BinutilsBuilder(Builder):
@@ -34,7 +28,7 @@ class BinutilsBuilder(Builder):
             '--with-system-zlib',
         ]
         # gprofng uses glibc APIs that might not be available on musl
-        if utils.libc_is_musl():
+        if tc_build.utils.libc_is_musl():
             self.configure_flags.append('--disable-gprofng')
         self.configure_vars = {
             'CC': 'gcc',
@@ -60,7 +54,7 @@ class BinutilsBuilder(Builder):
 
         self.clean_build_folder()
         self.folders.build.mkdir(exist_ok=True, parents=True)
-        utils.print_header(f"Building {self.target} binutils")
+        tc_build.utils.print_header(f"Building {self.target} binutils")
 
         configure_cmd = [
             Path(self.folders.source, 'configure'),
@@ -73,7 +67,7 @@ class BinutilsBuilder(Builder):
 
         if self.folders.install:
             self.run_cmd([*make_cmd, 'install'])
-            utils.create_gitignore(self.folders.install)
+            tc_build.utils.create_gitignore(self.folders.install)
 
 
 class StandardBinutilsBuilder(BinutilsBuilder):
@@ -222,4 +216,4 @@ class BinutilsSourceManager(SourceManager):
             self.tarball.download()
 
         self.tarball.extract(self.location)
-        utils.print_info(f"Source sucessfully prepared in {self.location}")
+        tc_build.utils.print_info(f"Source sucessfully prepared in {self.location}")

--- a/tc_build/source.py
+++ b/tc_build/source.py
@@ -4,11 +4,7 @@ import hashlib
 import re
 import subprocess
 
-# Allows being imported via tc_build package or directly in REPL
-try:
-    import utils
-except ModuleNotFoundError:
-    from . import utils
+import tc_build.utils
 
 # When doing verification, read 128MiB at a time
 BYTES_TO_READ = 131072
@@ -33,14 +29,14 @@ class Tarball:
         if not self.remote_tarball_name:
             self.remote_tarball_name = self.local_location.name
 
-        utils.curl(f"{self.base_download_url}/{self.remote_tarball_name}",
-                   destination=self.local_location)
+        tc_build.utils.curl(f"{self.base_download_url}/{self.remote_tarball_name}",
+                            destination=self.local_location)
 
         # If there is a remote checksum file, download it, find the checksum
         # for the particular tarball, compute the downloaded file's checksum,
         # and finally compare the two.
         if self.remote_checksum_name:
-            checksums = utils.curl(f"{self.base_download_url}/{self.remote_checksum_name}")
+            checksums = tc_build.utils.curl(f"{self.base_download_url}/{self.remote_checksum_name}")
             if not (match := re.search(
                     fr"([0-9a-f]+)\s+{self.remote_tarball_name}$", checksums, flags=re.M)):
                 raise RuntimeError(f"Could not find checksum for {self.remote_tarball_name}?")
@@ -80,7 +76,7 @@ class Tarball:
             '--strip-components=1',
         ]
 
-        utils.print_info(f"Extracting {self.local_location} into {extraction_location}...")
+        tc_build.utils.print_info(f"Extracting {self.local_location} into {extraction_location}...")
         subprocess.run(tar_cmd, check=True)
 
 

--- a/tc_build/tools.py
+++ b/tc_build/tools.py
@@ -7,11 +7,7 @@ import re
 import shutil
 import subprocess
 
-# Allows being imported via tc_build package or directly in REPL
-try:
-    import utils
-except ModuleNotFoundError:
-    from . import utils
+import tc_build.utils
 
 
 class HostTools:
@@ -120,7 +116,7 @@ class HostTools:
 
     def generate_versioned_binaries(self):
         try:
-            cmakelists_txt = utils.curl(
+            cmakelists_txt = tc_build.utils.curl(
                 'https://raw.githubusercontent.com/llvm/llvm-project/main/llvm/CMakeLists.txt')
         except subprocess.CalledProcessError:
             llvm_tot_ver = 16
@@ -140,7 +136,7 @@ class HostTools:
             else:
                 ld_to_print = self.ld if 'ld.' in self.ld else f"ld.{self.ld}"
                 print(f"LD: {shutil.which(ld_to_print)}")
-        utils.flush_std_err_out()
+        tc_build.utils.flush_std_err_out()
 
     def validate_ld(self, ld, warn=False):
         if not ld:
@@ -155,7 +151,7 @@ class HostTools:
                            text=True)
         except subprocess.CalledProcessError:
             if warn:
-                utils.print_warning(
+                tc_build.utils.print_warning(
                     f"LD value ('{ld}') is not supported by CC ('{self.cc}'), ignoring it...")
             return None
 


### PR DESCRIPTION
On OpenSUSE, there is a utils package in site-packages, which comes from
the pycparser package, conflicting directly with our own utils package.

To make sure everything works as expected, switch to absolute imports,
which avoids this pitfall. We already do this for the main Python
scripts.
