### PR TITLE
tc_build: kernel: Adjust PowerPC64 configuration target

### DIFF
--- a/tc_build/kernel.py
+++ b/tc_build/kernel.py
@@ -193,7 +193,7 @@ class PowerPC64KernelBuilder(PowerPCKernelBuilder):
     def __init__(self):
         super().__init__()
 
-        self.config_targets = ['pseries_defconfig', 'disable-werror.config']
+        self.config_targets = ['ppc64_guest_defconfig', 'disable-werror.config']
         self.cross_compile = 'powerpc64-linux-gnu-'
 
         # https://github.com/ClangBuiltLinux/linux/issues/602


### PR DESCRIPTION
A future kernel change will make pseries_defconfig a little endian
configuration. To keep PGO coverage for big endian, switch to
ppc64_guest_defconfig, which is roughtly equivalent.

Link: https://lore.kernel.org/20230414132415.821564-32-mpe@ellerman.id.au/
