### PR TITLE
Update default PGO kernel to 6.3.0 and update known good revision

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -14,7 +14,7 @@ from tc_build.kernel import KernelBuilder, LinuxSourceManager, LLVMKernelBuilder
 from tc_build.tools import HostTools, StageTools
 
 # This is a known good revision of LLVM for building the kernel
-GOOD_REVISION = '08b0977a1925cf0a2cf6f87fcbf1d656e873f7c5'
+GOOD_REVISION = '012ea747ed0275c499f69c82ac0f635f4c76f746'
 
 # The version of the Linux kernel that the script downloads if necessary
 DEFAULT_KERNEL_FOR_PGO = (6, 3, 0)

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -17,7 +17,7 @@ from tc_build.tools import HostTools, StageTools
 GOOD_REVISION = '08b0977a1925cf0a2cf6f87fcbf1d656e873f7c5'
 
 # The version of the Linux kernel that the script downloads if necessary
-DEFAULT_KERNEL_FOR_PGO = (6, 2, 8)
+DEFAULT_KERNEL_FOR_PGO = (6, 3, 0)
 
 parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
 clone_options = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
This has been qualified on aarch64 and x86_64 hosts using my
llvm-kernel-testing repository and those same hosts successfully booted
a kernel built from this revision on bare metal.

There is a new warning when building arm64 with ThinLTO but the fix from
012ea747ed0275c499f69c82ac0f635f4c76f746 is much more important than
that warning, which is entirely harmless for the moment. There are no
other major regressions that I am aware of.
