### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ These scripts have been tested in a Docker image of the following distributions 
               clang \
               cmake \
               curl \
-              libstdc++-12-dev \
               file \
               flex \
               git \
               libelf-dev \
               libssl-dev \
+              libstdc++-$(apt list libstdc++6 2>/dev/null | grep -Eos '[0-9]+\.[0-9]+\.[0-9]+' | head -1 | cut -d . -f 1)-dev \
               lld \
               make \
               ninja-build \

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ These scripts have been tested in a Docker image of the following distributions 
               clang \
               cmake \
               curl \
+              libstdc++-12-dev \
               file \
               flex \
               git \


### PR DESCRIPTION
Without libstdc++-12-dev build fails with
`/usr/bin/ld: cannot find -lstdc++: No such file or directory`


```
CMake Error at /usr/share/cmake-3.22/Modules/CMakeTestCXXCompiler.cmake:62 (message):
  The C++ compiler
    "/usr/lib/llvm-14/bin/clang++"
  is not able to compile a simple test program.
  It fails with the following output:
    Change Dir: /home/albert/rom/tc-build/build/llvm/bootstrap/CMakeFiles/CMakeTmp
    Run Build Command(s):/usr/bin/ninja cmTC_86a61 && [1/2] Building CXX object CMakeFiles/cmTC_86a61.dir/testCXXCompiler.cxx.o
    [2/2] Linking CXX executable cmTC_86a61
    FAILED: cmTC_86a61 
    : && /usr/lib/llvm-14/bin/clang++   CMakeFiles/cmTC_86a61.dir/testCXXCompiler.cxx.o -o cmTC_86a61   && :
    /usr/bin/ld: cannot find -lstdc++: No such file or directory
    clang: error: linker command failed with exit code 1 (use -v to see invocation)
    ninja: build stopped: subcommand failed.
  CMake will not be able to correctly generate this project.
Call Stack (most recent call first):
  CMakeLists.txt:47 (project)

```