### PR TITLE
Update default PGO kernel to 6.4.0 and update known good revision

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -17,7 +17,7 @@ from tc_build.tools import HostTools, StageTools
 GOOD_REVISION = '012ea747ed0275c499f69c82ac0f635f4c76f746'
 
 # The version of the Linux kernel that the script downloads if necessary
-DEFAULT_KERNEL_FOR_PGO = (6, 3, 0)
+DEFAULT_KERNEL_FOR_PGO = (6, 4, 0)
 
 parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
 clone_options = parser.add_mutually_exclusive_group()

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -14,7 +14,7 @@ from tc_build.kernel import KernelBuilder, LinuxSourceManager, LLVMKernelBuilder
 from tc_build.tools import HostTools, StageTools
 
 # This is a known good revision of LLVM for building the kernel
-GOOD_REVISION = '012ea747ed0275c499f69c82ac0f635f4c76f746'
+GOOD_REVISION = 'b5983a38cbf4eb405fe9583ab89e15db1dcfa173'
 
 # The version of the Linux kernel that the script downloads if necessary
 DEFAULT_KERNEL_FOR_PGO = (6, 4, 0)


### PR DESCRIPTION
This has been qualified on aarch64 and x86_64 hosts using my [llvm-kernel-testing](https://github.com/nathanchance/llvm-kernel-testing) repository.

I had initially wanted to use https://github.com/llvm/llvm-project/commit/99a1aeefb3d6be2018b591ed8c184c6f75fac386 as the known good revision for this upgrade (which is the parent of https://github.com/llvm/llvm-project/commit/d81ce04587c006b6731198956c522c93d0df105, which broke certain builds and is still being dealt with on the Linux side) but that revision is susceptible to warnings caused by https://github.com/llvm/llvm-project/commit/0123deb3a6f0a83095287f51b07c77b7b43ab847, which was fixed by https://github.com/llvm/llvm-project/commit/844e9534c6d99ddb6bada740839760fa24d17cb6, which occurs after https://github.com/llvm/llvm-project/commit/d81ce04587c006b6731198956c522c93d0df105). There is even more breakage from a patch similar to https://github.com/llvm/llvm-project/commit/d81ce04587c006b6731198956c522c93d0df105, https://github.com/llvm/llvm-project/commit/a79995ca6004082774a87f7a58ab6be5343364b7, which is not yet resolved, so be conservative and stay further back until it can be sorted out.
