### PR TITLE
tc_build: utils: Fix new Ruff warning (PIE808)

### DIFF
--- a/tc_build/utils.py
+++ b/tc_build/utils.py
@@ -60,7 +60,7 @@ def print_cyan(msg):
 
 
 def print_header(string):
-    border = ''.join(["=" for _ in range(0, len(string) + 6)])
+    border = ''.join(["=" for _ in range(len(string) + 6)])
     print_cyan(f"\n{border}\n== {string} ==\n{border}\n")
 
 


### PR DESCRIPTION
```
tc_build/utils.py:63:42: PIE808 [*] Unnecessary `start` argument in `range`
```

This is the result of `ruff check --fix .`.
