### PR TITLE
Update default PGO kernel to 6.5.0 and update known good revision

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -14,7 +14,7 @@ from tc_build.kernel import KernelBuilder, LinuxSourceManager, LLVMKernelBuilder
 from tc_build.tools import HostTools, StageTools
 
 # This is a known good revision of LLVM for building the kernel
-GOOD_REVISION = 'b5983a38cbf4eb405fe9583ab89e15db1dcfa173'
+GOOD_REVISION = 'e280e406c2e34ce29e1e71da7cd3a284ea112ce8'
 
 # The version of the Linux kernel that the script downloads if necessary
 DEFAULT_KERNEL_FOR_PGO = (6, 5, 0)

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -17,7 +17,7 @@ from tc_build.tools import HostTools, StageTools
 GOOD_REVISION = 'b5983a38cbf4eb405fe9583ab89e15db1dcfa173'
 
 # The version of the Linux kernel that the script downloads if necessary
-DEFAULT_KERNEL_FOR_PGO = (6, 4, 0)
+DEFAULT_KERNEL_FOR_PGO = (6, 5, 0)
 
 parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
 clone_options = parser.add_mutually_exclusive_group()

--- a/tc_build/kernel.py
+++ b/tc_build/kernel.py
@@ -287,6 +287,7 @@ class LLVMKernelBuilder(Builder):
             'AArch64': Arm64KernelBuilder,
             'ARM': ArmKernelBuilder,
             'Hexagon': HexagonKernelBuilder,
+            'PowerPC': PowerPC64KernelBuilder,
             'RISCV': RISCVKernelBuilder,
             'SystemZ': S390KernelBuilder,
             'X86': X8664KernelBuilder,

--- a/tc_build/kernel.py
+++ b/tc_build/kernel.py
@@ -16,7 +16,7 @@ class KernelBuilder(Builder):
     # If the user supplies their own kernel source, it must be at least this
     # version to ensure that all the build commands work, as the build commands
     # were written to target at least this version.
-    MINIMUM_SUPPORTED_VERSION = (6, 1, 7)
+    MINIMUM_SUPPORTED_VERSION = (6, 5, 0)
 
     def __init__(self, arch):
         super().__init__()
@@ -196,11 +196,16 @@ class PowerPC64KernelBuilder(PowerPCKernelBuilder):
         self.config_targets = ['ppc64_guest_defconfig', 'disable-werror.config']
         self.cross_compile = 'powerpc64-linux-gnu-'
 
-        # https://github.com/ClangBuiltLinux/linux/issues/602
-        self.make_variables['LD'] = self.cross_compile + 'ld'
+    # https://github.com/llvm/llvm-project/commit/33504b3bbe10d5d4caae13efcb99bd159c126070
+    def can_use_ias(self):
+        return self.toolchain_version >= (14, 0, 2)
+
+    # https://github.com/ClangBuiltLinux/linux/issues/1601
+    def needs_binutils(self):
+        return True
 
 
-class PowerPC64LEKernelBuilder(PowerPCKernelBuilder):
+class PowerPC64LEKernelBuilder(PowerPC64KernelBuilder):
 
     def __init__(self):
         super().__init__()
@@ -215,14 +220,6 @@ class PowerPC64LEKernelBuilder(PowerPCKernelBuilder):
             self.make_variables['LD'] = self.cross_compile + 'ld'
 
         super().build()
-
-    # https://github.com/llvm/llvm-project/commit/33504b3bbe10d5d4caae13efcb99bd159c126070
-    def can_use_ias(self):
-        return self.toolchain_version >= (14, 0, 2)
-
-    # https://github.com/ClangBuiltLinux/linux/issues/1601
-    def needs_binutils(self):
-        return True
 
 
 class RISCVKernelBuilder(KernelBuilder):


### PR DESCRIPTION
This pull request updates the default PGO kernel to 6.5.0 and bumps the known good revision for building the kernel.

As part of the update to 6.5.0, we are able to build `ARCH=powerpc allmodconfig` without any configuration changes and update the build options for `ppc64_guest_defconfig`. With this, we require users who supply their own kernel source to be on at least 6.5.0 as well.
