### PR TITLE
build-llvm.py: Utilize LLVM_DISTRIBUTION_COMPONENTS to build fewer targets

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -540,7 +540,7 @@ if (use_bootstrap := not args.build_stage1_only):
 
     bootstrap.check_dependencies()
     bootstrap.configure()
-    bootstrap.build()
+    bootstrap.build('distribution')
 
 # If the user did not specify CMAKE_C_FLAGS or CMAKE_CXX_FLAGS, add them as empty
 # to paste stage 2 to ensure there are no environment issues (since CFLAGS and CXXFLAGS
@@ -571,7 +571,7 @@ if args.pgo:
 
     tc_build.utils.print_header('Building LLVM (instrumented)')
     instrumented.configure()
-    instrumented.build()
+    instrumented.build('all' if args.full_toolchain else 'distribution')
 
     tc_build.utils.print_header('Generating PGO profiles')
     pgo_builders = []

--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -133,7 +133,7 @@ class LLVMBuilder(Builder):
         if mode == 'instrumentation':
             clang_inst.unlink()
 
-    def build(self):
+    def build(self, build_target='all'):
         if not self.folders.build:
             raise RuntimeError('No build folder set for build()?')
         if not Path(self.folders.build, 'build.ninja').exists():
@@ -142,7 +142,7 @@ class LLVMBuilder(Builder):
             raise RuntimeError('BOLT requested without a builder?')
 
         build_start = time.time()
-        ninja_cmd = ['ninja', '-C', self.folders.build]
+        ninja_cmd = ['ninja', '-C', self.folders.build, build_target]
         self.run_cmd(ninja_cmd)
 
         if self.check_targets:
@@ -363,6 +363,8 @@ class LLVMSlimBuilder(LLVMBuilder):
         }
 
         slim_llvm_defines = {
+            # Tools needed by bootstrapping
+            'LLVM_DISTRIBUTION_COMPONENTS': 'clang;clang-resource-headers;lld;llvm-ar;llvm-nm;llvm-ranlib;llvm-objcopy;llvm-objdump;llvm-readelf;llvm-strip',
             # Don't build bindings; they are for other languages that the kernel does not use
             'LLVM_ENABLE_BINDINGS': 'OFF',
             # Don't build Ocaml documentation
@@ -374,6 +376,10 @@ class LLVMSlimBuilder(LLVMBuilder):
             # Don't include example build targets to save on cmake cycles
             'LLVM_INCLUDE_EXAMPLES': 'OFF',
         }
+        if self.project_is_enabled('bolt'):
+            slim_llvm_defines['LLVM_DISTRIBUTION_COMPONENTS'] += ';bolt'
+        if self.project_is_enabled('compiler-rt'):
+            slim_llvm_defines['LLVM_DISTRIBUTION_COMPONENTS'] += ';llvm-profdata;profile'
 
         slim_compiler_rt_defines = {
             # Don't build libfuzzer when compiler-rt is enabled, it invokes cmake again and we don't use it

--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -364,7 +364,16 @@ class LLVMSlimBuilder(LLVMBuilder):
 
         slim_llvm_defines = {
             # Tools needed by bootstrapping
-            'LLVM_DISTRIBUTION_COMPONENTS': 'clang;clang-resource-headers;lld;llvm-ar;llvm-nm;llvm-ranlib;llvm-objcopy;llvm-objdump;llvm-readelf;llvm-strip',
+            'LLVM_DISTRIBUTION_COMPONENTS': ';'.join(['clang',
+                                                      'clang-resource-headers',
+                                                      'lld',
+                                                      'llvm-ar',
+                                                      'llvm-nm',
+                                                      'llvm-ranlib',
+                                                      'llvm-objcopy',
+                                                      'llvm-objdump',
+                                                      'llvm-readelf',
+                                                      'llvm-strip']),
             # Don't build bindings; they are for other languages that the kernel does not use
             'LLVM_ENABLE_BINDINGS': 'OFF',
             # Don't build Ocaml documentation


### PR DESCRIPTION
`build/llvm/bootstrap/bin/` contains a lot of LLVM and Clang tools that are not needed to build the kernel or later stages of Clang. Utilize LLVM_DISTRIBUTION_COMPONENTS to build fewer targets for 'bootstrap' and 'instrumented'. The `final` directory still contains everything.

When BOLT is disabled, we now just build the following executables:
```
% ls build/llvm/bootstrap/bin/
clang@     clang-cpp@     llvm-ar*          llvm-objcopy*   llvm-readelf@  wasm-ld@
clang++@   clang-tblgen*  llvm-lit*         llvm-objdump*   llvm-readobj*  ld64.lld@
clang-18*  lld*           llvm-min-tblgen*  llvm-profdata*  llvm-strip@    ld.lld@
clang-cl@  lld-link@      llvm-nm*          llvm-ranlib@    llvm-tblgen*
```

Tested:
  ./build-llvm.py --install-folder $PWD/install --projects clang lld --show-build-commands --targets X86 --pgo kernel-defconfig