### PR TITLE
build-llvm.py: Utilize thin archives

### DIFF
--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -226,6 +226,16 @@ class LLVMBuilder(Builder):
 
         if self.tools.ar:
             self.cmake_defines['CMAKE_AR'] = self.tools.ar
+        # Utilize thin archives to save space. Use the deprecated -T for
+        # compatibility with binutils<2.38 and llvm-ar<14. Unfortunately, thin
+        # archives make compiler-rt archives not easily distributable, so we
+        # disable the optimization when compiler-rt is enabled and there is an
+        # install directory. Ideally thin archives should still be usable for
+        # non-compiler-rt projects.
+        if not (self.folders.install and self.project_is_enabled('compiler-rt')):
+            self.cmake_defines['CMAKE_CXX_ARCHIVE_CREATE'] = '<CMAKE_AR> DqcT <TARGET> <OBJECTS>'
+        self.cmake_defines['CMAKE_CXX_ARCHIVE_FINISH'] = 'true'
+
         if self.tools.ranlib:
             self.cmake_defines['CMAKE_RANLIB'] = self.tools.ranlib
         if 'CMAKE_BUILD_TYPE' not in self.cmake_defines:


### PR DESCRIPTION
Copying .o files into archives are wasteful. Utilize thin archives to reclaim wasted space. Use the deprecated -T for compatibility with binutils<2.38 and llvm-ar<14.

See https://maskray.me/blog/2022-01-16-archives-and-start-lib for some notes about thin archives and useless archive symbol tables. In an ideal world where GNU ld did not read archive symbol tables, we could specify -S to save more space.