### PR TITLE
tc_build: llvm: Fix distribution_components with disabled projects

### DIFF
--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -375,15 +375,19 @@ class LLVMSlimBuilder(LLVMBuilder):
         llvm_build_runtime = self.cmake_defines.get('LLVM_BUILD_RUNTIME', 'ON') == 'ON'
         build_compiler_rt = self.project_is_enabled('compiler-rt') and llvm_build_runtime
 
-        distribution_components = [
-            'llvm-ar',
-            'llvm-nm',
-            'llvm-objcopy',
-            'llvm-objdump',
-            'llvm-ranlib',
-            'llvm-readelf',
-            'llvm-strip',
-        ]
+        llvm_build_tools = self.cmake_defines.get('LLVM_BUILD_TOOLS', 'ON') == 'ON'
+
+        distribution_components = []
+        if llvm_build_tools:
+            distribution_components += [
+                'llvm-ar',
+                'llvm-nm',
+                'llvm-objcopy',
+                'llvm-objdump',
+                'llvm-ranlib',
+                'llvm-readelf',
+                'llvm-strip',
+            ]
         if self.project_is_enabled('bolt'):
             distribution_components.append('bolt')
         if self.project_is_enabled('clang'):

--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -376,9 +376,6 @@ class LLVMSlimBuilder(LLVMBuilder):
         build_compiler_rt = self.project_is_enabled('compiler-rt') and llvm_build_runtime
 
         distribution_components = [
-            'clang',
-            'clang-resource-headers',
-            'lld',
             'llvm-ar',
             'llvm-nm',
             'llvm-objcopy',
@@ -389,6 +386,10 @@ class LLVMSlimBuilder(LLVMBuilder):
         ]
         if self.project_is_enabled('bolt'):
             distribution_components.append('bolt')
+        if self.project_is_enabled('clang'):
+            distribution_components += ['clang', 'clang-resource-headers']
+        if self.project_is_enabled('lld'):
+            distribution_components.append('lld')
         if build_compiler_rt:
             distribution_components += ['llvm-profdata', 'profile']
 


### PR DESCRIPTION
It is possible to use `--projects` to build certain combinations of subprojects, such as just `llvm` or `clang` to build just LLVM or LLVM and clang respectively. When either the `clang` or `lld` subproject is not enabled, there is an error when running `cmake` due to their targets being present in the distributions components list.

Only add them to `distribution_components` if the projects that contain them are enabled.
