### PR TITLE
build-llvm.py: Add '--build-targets'

### DIFF
--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -27,6 +27,7 @@ class LLVMBuilder(Builder):
 
         self.bolt = False
         self.bolt_builder = None
+        self.build_targets = ['all']
         self.ccache = False
         self.check_targets = []
         # Removes system dependency on terminfo to keep the dynamic library
@@ -133,7 +134,7 @@ class LLVMBuilder(Builder):
         if mode == 'instrumentation':
             clang_inst.unlink()
 
-    def build(self, build_target='all'):
+    def build(self):
         if not self.folders.build:
             raise RuntimeError('No build folder set for build()?')
         if not Path(self.folders.build, 'build.ninja').exists():
@@ -142,7 +143,7 @@ class LLVMBuilder(Builder):
             raise RuntimeError('BOLT requested without a builder?')
 
         build_start = time.time()
-        ninja_cmd = ['ninja', '-C', self.folders.build, build_target]
+        ninja_cmd = ['ninja', '-C', self.folders.build, *self.build_targets]
         self.run_cmd(ninja_cmd)
 
         if self.check_targets:


### PR DESCRIPTION
It can be useful to select subtargets, like `clang` or `llvm-ar`, to build single tools when issues are isolated to them, which can reduce build time. This provides tangible benefits when bisecting, as an issue can be isolated down to a single commit in less time.

As part of this implementation, the build target parameter is added as a member to `LLVMBuilder` and changed to a list to be more flexible and fit in more with how customizing the builder works in the rest of `tc_build/`.
