### PR TITLE
Update default PGO kernel to 6.6.0 and update known good revision

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -14,7 +14,7 @@ from tc_build.kernel import KernelBuilder, LinuxSourceManager, LLVMKernelBuilder
 from tc_build.tools import HostTools, StageTools
 
 # This is a known good revision of LLVM for building the kernel
-GOOD_REVISION = 'e280e406c2e34ce29e1e71da7cd3a284ea112ce8'
+GOOD_REVISION = '0f8615f4dc568f4d7cbf73580eef3e78f64f3bd0'
 
 # The version of the Linux kernel that the script downloads if necessary
 DEFAULT_KERNEL_FOR_PGO = (6, 6, 0)

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -17,7 +17,7 @@ from tc_build.tools import HostTools, StageTools
 GOOD_REVISION = 'e280e406c2e34ce29e1e71da7cd3a284ea112ce8'
 
 # The version of the Linux kernel that the script downloads if necessary
-DEFAULT_KERNEL_FOR_PGO = (6, 5, 0)
+DEFAULT_KERNEL_FOR_PGO = (6, 6, 0)
 
 parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
 clone_options = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
This has been qualified on aarch64 and x86_64 hosts using my llvm-kernel-testing repository.

LoongArch builds are currently broken at this revision but [the fix](https://lore.kernel.org/20231102-loongarch-always-inline-percpu-ops-v2-1-31c51959a5c0@kernel.org/) should hopefully be picked up and backported to all relevant releases in a relatively timely manner, so I don't think it is worth changing the revision just for this.
