### PR TITLE
A couple of ci.sh updates

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -99,7 +99,7 @@ function do_llvm() {
         --install-folder "$install" \
         --projects clang lld \
         --quiet-cmake \
-        --ref release/16.x \
+        --ref release/17.x \
         --shallow-clone \
         --show-build-commands \
         --targets X86 \

--- a/ci.sh
+++ b/ci.sh
@@ -95,8 +95,10 @@ function do_llvm() {
     "$base"/build-llvm.py \
         --assertions \
         --build-stage1-only \
+        --build-target distribution \
         --check-targets clang lld llvm \
         --install-folder "$install" \
+        --install-target distribution \
         --projects clang lld \
         --quiet-cmake \
         --ref release/17.x \


### PR DESCRIPTION
The first change moves `ci.sh` to use `release/17.x`, the latest stable release branch.

The second makes the build slimmer so that there is less room for random build breakage as well as faster builds. This is just a smoke test after all.
