### PR TITLE
tc_build: llvm: Move use of build_targets out of ninja_cmd

### DIFF
--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -143,12 +143,12 @@ class LLVMBuilder(Builder):
             raise RuntimeError('BOLT requested without a builder?')
 
         build_start = time.time()
-        ninja_cmd = ['ninja', '-C', self.folders.build, *self.build_targets]
-        self.run_cmd(ninja_cmd)
+        base_ninja_cmd = ['ninja', '-C', self.folders.build]
+        self.run_cmd([*base_ninja_cmd, *self.build_targets])
 
         if self.check_targets:
             check_targets = [f"check-{target}" for target in self.check_targets]
-            self.run_cmd([*ninja_cmd, *check_targets])
+            self.run_cmd([*base_ninja_cmd, *check_targets])
 
         tc_build.utils.print_info(f"Build duration: {tc_build.utils.get_duration(build_start)}")
 
@@ -160,7 +160,7 @@ class LLVMBuilder(Builder):
                 install_targets = [f"install-{target}" for target in self.install_targets]
             else:
                 install_targets = ['install']
-            self.run_cmd([*ninja_cmd, *install_targets], capture_output=True)
+            self.run_cmd([*base_ninja_cmd, *install_targets], capture_output=True)
             tc_build.utils.create_gitignore(self.folders.install)
 
     def can_use_perf(self):


### PR DESCRIPTION
Otherwise, they will get added to each invocation of `ninja`. `build_target` should have been added to just the `self.run_cmd(ninja_cmd)`. While this does not (currently) cause any problems, it is unnecessary to specify the base build targets on each subsequent invocation of `ninja` because they will have already been built.

To make it clearer for the future, rename `ninja_cmd` to `base_ninja_cmd`.
