### PR TITLE
tc_build: llvm: Update BOLT flags

### DIFF
--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -115,6 +115,9 @@ class LLVMBuilder(Builder):
             self.bolt_builder.bolt_sampling_output.unlink()
 
         # Now actually optimize clang
+        bolt_readme = Path(self.folders.source, 'bolt/README.md').read_text(encoding='utf-8')
+        use_cache_plus = '-reorder-blocks=cache+' in bolt_readme
+        use_sf_val = '-split-functions=2' in bolt_readme
         clang_opt_cmd = [
             self.tools.llvm_bolt,
             f"--data={bolt_profile}",
@@ -122,10 +125,10 @@ class LLVMBuilder(Builder):
             '--icf=1',
             '-o',
             clang_bolt,
-            '--reorder-blocks=cache+',
+            f"--reorder-blocks={'cache+' if use_cache_plus else 'ext-tsp'}",
             '--reorder-functions=hfsort+',
             '--split-all-cold',
-            '--split-functions=3',
+            f"--split-functions{'=3' if use_sf_val else ''}",
             '--use-gnu-stack',
             clang,
         ]


### PR DESCRIPTION
Resolves the following warnings when performing BOLT:

  BOLT-WARNING: '-reorder-blocks=cache+' is deprecated, please use '-reorder-blocks=ext-tsp' instead
  BOLT-WARNING: specifying non-boolean value "3" for option -split-functions is deprecated

Which matches the updated docs:

https://github.com/llvm/llvm-project/commit/38fb7d56e543f3cd137a79d6e6331b697ef9f92c
https://github.com/llvm/llvm-project/commit/96f6ec5090c2f7a1e4804693cbb84c29c574b3de
