### PR TITLE
build-binutils.py: 2.42

### DIFF
--- a/build-binutils.py
+++ b/build-binutils.py
@@ -8,7 +8,7 @@ import time
 import tc_build.binutils
 import tc_build.utils
 
-LATEST_BINUTILS_RELEASE = (2, 41, 0)
+LATEST_BINUTILS_RELEASE = (2, 42, 0)
 
 parser = ArgumentParser()
 parser.add_argument('-B',


### PR DESCRIPTION
This is the latest binutils release:

https://lists.gnu.org/archive/html/info-gnu/2024-01/msg00016.html
