### PR TITLE
workflows: lint: Add Python 3.12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          version: ['3.11', '3.10', '3.9', '3.8']
+          version: ['3.12', '3.11', '3.10', '3.9', '3.8']
       uses: ClangBuiltLinux/actions-workflows/.github/workflows/python_lint.yml@main
       with:
         python_version: ${{ matrix.version }}


### PR DESCRIPTION
We should ensure our code stays compatible with the latest stable release of Python.
