### PR TITLE
tc_build: tools: Update location of LLVM_VERSION_MAJOR

### DIFF
--- a/tc_build/tools.py
+++ b/tc_build/tools.py
@@ -117,9 +117,10 @@ class HostTools:
     def generate_versioned_binaries(self):
         try:
             cmakelists_txt = tc_build.utils.curl(
-                'https://raw.githubusercontent.com/llvm/llvm-project/main/llvm/CMakeLists.txt')
+                'https://raw.githubusercontent.com/llvm/llvm-project/main/cmake/Modules/LLVMVersion.cmake'
+            )
         except subprocess.CalledProcessError:
-            llvm_tot_ver = 16
+            llvm_tot_ver = 19
         else:
             if not (match := re.search(r'set\(LLVM_VERSION_MAJOR\s+(\d+)', cmakelists_txt)):
                 raise RuntimeError('Could not find LLVM_VERSION_MAJOR in CMakeLists.txt?')


### PR DESCRIPTION
It was moved in https://github.com/llvm/llvm-project/commit/81e20472a0c5a4a8edc5ec38dc345d580681af81.

Closes: https://github.com/ClangBuiltLinux/tc-build/issues/262
