### PR TITLE
Update default PGO kernel to 6.8.0 and update known good revision

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -17,7 +17,7 @@ from tc_build.tools import HostTools, StageTools
 GOOD_REVISION = 'a828cda9c80282a77b579f8fc9dc17a310173af4'
 
 # The version of the Linux kernel that the script downloads if necessary
-DEFAULT_KERNEL_FOR_PGO = (6, 7, 0)
+DEFAULT_KERNEL_FOR_PGO = (6, 8, 0)
 
 parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
 clone_options = parser.add_mutually_exclusive_group()

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -14,7 +14,7 @@ from tc_build.kernel import KernelBuilder, LinuxSourceManager, LLVMKernelBuilder
 from tc_build.tools import HostTools, StageTools
 
 # This is a known good revision of LLVM for building the kernel
-GOOD_REVISION = 'a828cda9c80282a77b579f8fc9dc17a310173af4'
+GOOD_REVISION = '2e39b57837aa1790b3ee078fa532bb1748a609c7'
 
 # The version of the Linux kernel that the script downloads if necessary
 DEFAULT_KERNEL_FOR_PGO = (6, 8, 0)


### PR DESCRIPTION
This has been qualified on aarch64 and x86_64 hosts using my [llvm-kernel-testing](https://github.com/nathanchance/llvm-kernel-testing) repository.
