### PR TITLE
Update DEFAULT_KERNEL_FOR_PGO to 6.10.0

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -17,7 +17,7 @@ from tc_build.tools import HostTools, StageTools
 GOOD_REVISION = '15397583e3d85eb1f1a051de26eb409aaedd3b54'
 
 # The version of the Linux kernel that the script downloads if necessary
-DEFAULT_KERNEL_FOR_PGO = (6, 9, 0)
+DEFAULT_KERNEL_FOR_PGO = (6, 10, 0)
 
 parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
 clone_options = parser.add_mutually_exclusive_group()

--- a/src/2bac084468847cfe5bbc7166082b2a208514bb1c.patch
+++ b/src/2bac084468847cfe5bbc7166082b2a208514bb1c.patch
@@ -1,0 +1,69 @@
+From 2bac084468847cfe5bbc7166082b2a208514bb1c Mon Sep 17 00:00:00 2001
+From: Bill Wendling <morbo@google.com>
+Date: Wed, 29 May 2024 14:54:44 -0700
+Subject: drm/radeon: Remove __counted_by from StateArray.states[]
+
+Work for __counted_by on generic pointers in structures (not just
+flexible array members) has started landing in Clang 19 (current tip of
+tree). During the development of this feature, a restriction was added
+to __counted_by to prevent the flexible array member's element type from
+including a flexible array member itself such as:
+
+  struct foo {
+    int count;
+    char buf[];
+  };
+
+  struct bar {
+    int count;
+    struct foo data[] __counted_by(count);
+  };
+
+because the size of data cannot be calculated with the standard array
+size formula:
+
+  sizeof(struct foo) * count
+
+This restriction was downgraded to a warning but due to CONFIG_WERROR,
+it can still break the build. The application of __counted_by on the
+states member of 'struct _StateArray' triggers this restriction,
+resulting in:
+
+  drivers/gpu/drm/radeon/pptable.h:442:5: error: 'counted_by' should not be applied to an array with element of unknown size because 'ATOM_PPLIB_STATE_V2' (aka 'struct _ATOM_PPLIB_STATE_V2') is a struct type with a flexible array member. This will be an error in a future compiler version [-Werror,-Wbounds-safety-counted-by-elt-type-unknown-size]
+    442 |     ATOM_PPLIB_STATE_V2 states[] __counted_by(ucNumEntries);
+        |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  1 error generated.
+
+Remove this use of __counted_by to fix the warning/error. However,
+rather than remove it altogether, leave it commented, as it may be
+possible to support this in future compiler releases.
+
+Cc: stable@vger.kernel.org
+Closes: https://github.com/ClangBuiltLinux/linux/issues/2028
+Fixes: efade6fe50e7 ("drm/radeon: silence UBSAN warning (v3)")
+Signed-off-by: Bill Wendling <morbo@google.com>
+Co-developed-by: Nathan Chancellor <nathan@kernel.org>
+Signed-off-by: Nathan Chancellor <nathan@kernel.org>
+Signed-off-by: Alex Deucher <alexander.deucher@amd.com>
+---
+Link: https://git.kernel.org/linus/2bac084468847cfe5bbc7166082b2a208514bb1c
+---
+ drivers/gpu/drm/radeon/pptable.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/radeon/pptable.h b/drivers/gpu/drm/radeon/pptable.h
+index b7f22597ee95e7..969a8fb0ee9e0b 100644
+--- a/drivers/gpu/drm/radeon/pptable.h
++++ b/drivers/gpu/drm/radeon/pptable.h
+@@ -439,7 +439,7 @@ typedef struct _StateArray{
+     //how many states we have 
+     UCHAR ucNumEntries;
+     
+-    ATOM_PPLIB_STATE_V2 states[] __counted_by(ucNumEntries);
++    ATOM_PPLIB_STATE_V2 states[] /* __counted_by(ucNumEntries) */;
+ }StateArray;
+ 
+ 
+-- 
+cgit 1.2.3-korg
+


### PR DESCRIPTION
I have not included an update to the known good revision this time around, as there are several known regressions in tip of tree and I have not had time to try and qualify both that uprev and this one. This one should be safe with the coverage that we have had in CI.
