### PR TITLE
tc_build: Improve source set up logging

### DIFF
--- a/tc_build/kernel.py
+++ b/tc_build/kernel.py
@@ -459,7 +459,10 @@ class LinuxSourceManager(SourceManager):
                 # been applied.
                 if 'Reversed (or previously applied) patch detected' in err.stdout:
                     tc_build.utils.print_warning(
-                        f"Patch ('{patch}') has already been applied, consider removing it")
+                        f"{patch} has already been applied in {self.location}, consider removing it"
+                    )
                 else:
                     raise err
-        tc_build.utils.print_info(f"Source sucessfully prepared in {self.location}")
+            else:
+                tc_build.utils.print_info(f"Applied {patch} to {self.location}")
+        tc_build.utils.print_info(f"Source successfully prepared in {self.location}")

--- a/tc_build/source.py
+++ b/tc_build/source.py
@@ -29,8 +29,9 @@ class Tarball:
         if not self.remote_tarball_name:
             self.remote_tarball_name = self.local_location.name
 
-        tc_build.utils.curl(f"{self.base_download_url}/{self.remote_tarball_name}",
-                            destination=self.local_location)
+        full_url = f"{self.base_download_url}/{self.remote_tarball_name}"
+        tc_build.utils.print_info(f"Downloading {full_url} to {self.local_location}...")
+        tc_build.utils.curl(full_url, destination=self.local_location)
 
         # If there is a remote checksum file, download it, find the checksum
         # for the particular tarball, compute the downloaded file's checksum,


### PR DESCRIPTION
Include more information when setting up the source, such as:

- An informational print about downloading the source in case the connection is slow so the user knows something is happening in the background.

- An informational print for every patch that gets applied, so that the user is aware the source is not clean.

- Updating the wording of a message to be a little more descriptive about source location.

- Cleaning up the spelling in one message.
