### PR TITLE
tc_build: kernel: Silence new ruff warning (SIM115)

### DIFF
--- a/tc_build/kernel.py
+++ b/tc_build/kernel.py
@@ -79,7 +79,7 @@ class KernelBuilder(Builder):
             # try: ... finally: ... statement to ensure that this file is
             # always cleaned up.
             # pylint: disable-next=consider-using-with
-            kconfig_allconfig = NamedTemporaryFile(dir=self.folders.build)
+            kconfig_allconfig = NamedTemporaryFile(dir=self.folders.build)  # noqa: SIM115
 
             configs_to_disable = ['DRM_WERROR', 'WERROR']
             kconfig_allconfig_text = ''.join(f"CONFIG_{val}=n\n"


### PR DESCRIPTION
This is the same warning that we already disable for `pylint`, for the reasons outlined in the comment block above this.

```
tc_build/kernel.py:82:33: SIM115 Use a context manager for opening files
   |
80 |             # always cleaned up.
81 |             # pylint: disable-next=consider-using-with
82 |             kconfig_allconfig = NamedTemporaryFile(dir=self.folders.build)
   |                                 ^^^^^^^^^^^^^^^^^^ SIM115
83 |
84 |             configs_to_disable = ['DRM_WERROR', 'WERROR']
   |

Found 1 error.
```
