### PR TITLE
tc_build: llvm: Add Sparc to default targets

### DIFF
--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -533,7 +533,10 @@ class LLVMSourceManager:
 
     def default_targets(self):
         all_targets = get_all_targets(self.repo)
-        targets = ['AArch64', 'ARM', 'BPF', 'Hexagon', 'Mips', 'PowerPC', 'RISCV', 'SystemZ', 'X86']
+        targets = [
+            'AArch64', 'ARM', 'BPF', 'Hexagon', 'Mips', 'PowerPC', 'RISCV', 'Sparc', 'SystemZ',
+            'X86'
+        ]
 
         if 'LoongArch' in all_targets:
             targets.append('LoongArch')


### PR DESCRIPTION
There is some effort to build `ARCH=sparc` with Clang. Add it to the default targets list so that toolchains built with tc-build can easily test these patches.
