### PR TITLE
tc_build/binutils: Dont install unwanted man pages and info files

### DIFF
--- a/tc_build/binutils.py
+++ b/tc_build/binutils.py
@@ -3,6 +3,7 @@
 import os
 from pathlib import Path
 import platform
+from tempfile import TemporaryDirectory
 
 from tc_build.builder import Builder
 from tc_build.source import SourceManager
@@ -28,6 +29,7 @@ class BinutilsBuilder(Builder):
             '--quiet',
             '--with-system-zlib',
         ]
+
         self.configure_vars = {
             'CC': 'gcc',
             'CXX': 'g++',
@@ -66,6 +68,8 @@ class BinutilsBuilder(Builder):
         if self.folders.install:
             self.run_cmd([*make_cmd, 'install'])
             tc_build.utils.create_gitignore(self.folders.install)
+            # Clean temporary dir containing docs after installing
+            self.tmpdir.cleanup()
 
 
 class StandardBinutilsBuilder(BinutilsBuilder):

--- a/tc_build/binutils.py
+++ b/tc_build/binutils.py
@@ -56,7 +56,8 @@ class BinutilsBuilder(Builder):
         self.folders.build.mkdir(exist_ok=True, parents=True)
         tc_build.utils.print_header(f"Building {self.target} binutils")
 
-        # Redirect unwanted docs to a temporary dir
+        # Binutils does not provide a configuration flag to disable installation of documentation directly.
+        # Instead, we redirect generated docs to a temporary directory, deleting them after installation.
         with TemporaryDirectory() as tmpdir:
             doc_dirs = ('info', 'html', 'pdf', 'man')
             self.configure_flags += [f"--{doc}dir={tmpdir}" for doc in doc_dirs]

--- a/tc_build/binutils.py
+++ b/tc_build/binutils.py
@@ -58,8 +58,8 @@ class BinutilsBuilder(Builder):
 
         # Redirect unwanted docs to a temporary dir
         with TemporaryDirectory() as tmpdir:
-            doc_dirs = ['infodir', 'htmldir', 'pdfdir', 'mandir']
-            self.configure_flags += [f"--{d}={tmpdir}" for d in doc_dirs]
+            doc_dirs = ('info', 'html', 'pdf', 'man')
+            self.configure_flags += [f"--{doc}dir={tmpdir}" for doc in doc_dirs]
 
             configure_cmd = [
                 Path(self.folders.source, 'configure'),


### PR DESCRIPTION
We disable installation of docs for LLVM already, similarly modify the Binutils build process to redirect the installation of doc files to a temporary directory (/tmp/tc-build/deleteme) and delete it after the build and installation process finishes.

Files that get redirected:
$ find /tmp/tc-build/deleteme/
<details>
  <summary>Click to expand</summary>

> /tmp/tc-build/deleteme/dir
> /tmp/tc-build/deleteme/ldint.info
> /tmp/tc-build/deleteme/ld.info
> /tmp/tc-build/deleteme/binutils.info
> /tmp/tc-build/deleteme/ctf-spec.info
> /tmp/tc-build/deleteme/bfd.info
> /tmp/tc-build/deleteme/as.info
> /tmp/tc-build/deleteme/gprof.info
> /tmp/tc-build/deleteme/sframe-spec.info
> /tmp/tc-build/deleteme/gprofng.info
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-ld.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-c++filt.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-windmc.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-windres.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-elfedit.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-strip.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-strings.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-size.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-readelf.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-ranlib.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-objdump.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-objcopy.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-nm.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-dlltool.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-ar.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-addr2line.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-as.1
> /tmp/tc-build/deleteme/man1/loongarch64-linux-gnu-gprof.1
> /tmp/tc-build/deleteme/man1/gp-display-text.1
> /tmp/tc-build/deleteme/man1/gp-display-src.1
> /tmp/tc-build/deleteme/man1/gp-display-html.1
> /tmp/tc-build/deleteme/man1/gp-collect-app.1
> /tmp/tc-build/deleteme/man1/gp-archive.1
> /tmp/tc-build/deleteme/man1/gprofng.1
> /tmp/tc-build/deleteme/man1/ld.1
> /tmp/tc-build/deleteme/man1/c++filt.1
> /tmp/tc-build/deleteme/man1/windmc.1
> /tmp/tc-build/deleteme/man1/windres.1
> /tmp/tc-build/deleteme/man1/elfedit.1
> /tmp/tc-build/deleteme/man1/strip.1
> /tmp/tc-build/deleteme/man1/strings.1
> /tmp/tc-build/deleteme/man1/size.1
> /tmp/tc-build/deleteme/man1/readelf.1
> /tmp/tc-build/deleteme/man1/ranlib.1
> /tmp/tc-build/deleteme/man1/objdump.1
> /tmp/tc-build/deleteme/man1/objcopy.1
> /tmp/tc-build/deleteme/man1/nm.1
> /tmp/tc-build/deleteme/man1/dlltool.1
> /tmp/tc-build/deleteme/man1/ar.1
> /tmp/tc-build/deleteme/man1/addr2line.1
> /tmp/tc-build/deleteme/man1/as.1
> /tmp/tc-build/deleteme/man1/gprof.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-ld.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-c++filt.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-windmc.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-windres.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-elfedit.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-strip.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-strings.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-size.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-readelf.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-ranlib.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-objdump.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-objcopy.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-nm.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-dlltool.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-ar.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-addr2line.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-as.1
> /tmp/tc-build/deleteme/man1/s390x-linux-gnu-gprof.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-gp-display-text.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-gp-display-src.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-gp-display-html.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-gp-collect-app.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-gp-archive.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-gprofng.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-ld.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-c++filt.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-windmc.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-windres.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-elfedit.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-strip.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-strings.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-size.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-readelf.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-ranlib.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-objdump.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-objcopy.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-nm.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-dlltool.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-ar.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-addr2line.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-as.1
> /tmp/tc-build/deleteme/man1/riscv64-linux-gnu-gprof.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-ld.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-c++filt.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-windmc.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-windres.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-elfedit.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-strip.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-strings.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-size.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-readelf.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-ranlib.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-objdump.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-objcopy.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-nm.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-dlltool.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-ar.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-addr2line.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-as.1
> /tmp/tc-build/deleteme/man1/powerpc64le-linux-gnu-gprof.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-ld.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-c++filt.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-windmc.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-windres.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-elfedit.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-strip.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-strings.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-size.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-readelf.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-ranlib.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-objdump.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-objcopy.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-nm.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-dlltool.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-ar.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-addr2line.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-as.1
> /tmp/tc-build/deleteme/man1/powerpc64-linux-gnu-gprof.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-ld.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-c++filt.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-windmc.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-windres.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-elfedit.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-strip.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-strings.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-size.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-readelf.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-ranlib.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-objdump.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-objcopy.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-nm.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-dlltool.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-ar.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-addr2line.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-as.1
> /tmp/tc-build/deleteme/man1/powerpc-linux-gnu-gprof.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-ld.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-c++filt.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-windmc.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-windres.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-elfedit.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-strip.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-strings.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-size.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-readelf.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-ranlib.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-objdump.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-objcopy.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-nm.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-dlltool.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-ar.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-addr2line.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-as.1
> /tmp/tc-build/deleteme/man1/mipsel-linux-gnu-gprof.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-ld.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-c++filt.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-windmc.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-windres.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-elfedit.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-strip.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-strings.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-size.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-readelf.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-ranlib.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-objdump.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-objcopy.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-nm.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-dlltool.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-ar.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-addr2line.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-as.1
> /tmp/tc-build/deleteme/man1/mips-linux-gnu-gprof.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-ld.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-c++filt.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-windmc.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-windres.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-elfedit.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-strip.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-strings.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-size.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-readelf.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-ranlib.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-objdump.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-objcopy.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-nm.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-dlltool.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-ar.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-addr2line.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-as.1
> /tmp/tc-build/deleteme/man1/arm-linux-gnueabi-gprof.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-gp-display-text.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-gp-display-src.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-gp-display-html.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-gp-collect-app.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-gp-archive.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-gprofng.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-ld.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-c++filt.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-windmc.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-windres.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-elfedit.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-strip.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-strings.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-size.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-readelf.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-ranlib.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-objdump.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-objcopy.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-nm.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-dlltool.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-ar.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-addr2line.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-as.1
> /tmp/tc-build/deleteme/man1/aarch64-linux-gnu-gprof.1

</details>