### PR TITLE
Update DEFAULT_KERNEL_FOR_PGO to 6.13.0 and bump known good revision

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -14,7 +14,7 @@ from tc_build.kernel import KernelBuilder, LinuxSourceManager, LLVMKernelBuilder
 from tc_build.tools import HostTools, StageTools
 
 # This is a known good revision of LLVM for building the kernel
-GOOD_REVISION = '2ab9233f4f393c240c37ef092de09d907fe5c890'
+GOOD_REVISION = '5ce271ef74dd3325993c827f496e460ced41af11'
 
 # The version of the Linux kernel that the script downloads if necessary
 DEFAULT_KERNEL_FOR_PGO = (6, 13, 0)

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -17,7 +17,7 @@ from tc_build.tools import HostTools, StageTools
 GOOD_REVISION = '2ab9233f4f393c240c37ef092de09d907fe5c890'
 
 # The version of the Linux kernel that the script downloads if necessary
-DEFAULT_KERNEL_FOR_PGO = (6, 12, 0)
+DEFAULT_KERNEL_FOR_PGO = (6, 13, 0)
 
 parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
 clone_options = parser.add_mutually_exclusive_group()

--- a/tc_build/binutils.py
+++ b/tc_build/binutils.py
@@ -18,6 +18,7 @@ class BinutilsBuilder(Builder):
         self.configure_flags = [
             '--disable-compressed-debug-sections',
             '--disable-gdb',
+            '--disable-gprofng',
             '--disable-nls',
             '--disable-werror',
             '--enable-deterministic-archives',
@@ -27,9 +28,6 @@ class BinutilsBuilder(Builder):
             '--quiet',
             '--with-system-zlib',
         ]
-        # gprofng uses glibc APIs that might not be available on musl
-        if tc_build.utils.libc_is_musl():
-            self.configure_flags.append('--disable-gprofng')
         self.configure_vars = {
             'CC': 'gcc',
             'CXX': 'g++',


### PR DESCRIPTION
See the individual changes for the full details. This has been qualified on aarch64 and x86_64 hosts using my [llvm-kernel-testing](https://github.com/nathanchance/llvm-kernel-testing) repository.
