### PR TITLE
ci.sh: Update to release/20.x

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -101,7 +101,7 @@ function do_llvm() {
         --install-target distribution \
         --projects clang lld \
         --quiet-cmake \
-        --ref release/19.x \
+        --ref release/20.x \
         --shallow-clone \
         --show-build-commands \
         --targets X86 \


### PR DESCRIPTION
While the branch has not been released yet, we want to make sure that we start testing early to catch any potential problems.
