### PR TITLE
tc_build: llvm: Add 'runtimes' to distribution

### DIFF
--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -434,6 +434,7 @@ class LLVMSlimBuilder(LLVMBuilder):
         if build_compiler_rt:
             distribution_components.append('llvm-profdata')
             if self.llvm_major_version >= 21:
+                distribution_components.append('runtimes')
                 runtime_distribution_components.append('profile')
             else:
                 distribution_components.append('profile')


### PR DESCRIPTION
In order for the compiler-rt profile library to be built after the switch to the runtimes build, the runtimes target needs to be added to the distribution components. This fixes the build with PGO.
