### PR TITLE
fix(ci): drop EOL Python version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          version: ['3.13', '3.12', '3.11', '3.10', '3.9', '3.8']
+          version: ['3.13', '3.12', '3.11', '3.10', '3.9']
       uses: ClangBuiltLinux/actions-workflows/.github/workflows/python_lint.yml@main
       with:
         python_version: ${{ matrix.version }}

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-target-version = 'py38'
+target-version = 'py39'
 
 # https://docs.astral.sh/ruff/rules/
 [lint]


### PR DESCRIPTION
According to https://endoflife.date/python Python 3.8 no longer has security support as of 5 months ago.

IMO we should also drop Python 3.9 since it will lose security support 7 months from now but we can defer that
to when the time arrives, hence it is not included in this PR.
