### PR TITLE
ci.sh: Update mirrorlist before installing dependencies

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -34,6 +34,9 @@ function do_deps() {
     # We only run this when running on GitHub Actions
     [[ -z ${GITHUB_ACTIONS:-} ]] && return 0
 
+    # Refresh mirrorlist to avoid dead mirrors
+    sudo apt-get update -y
+
     sudo apt-get install -y --no-install-recommends \
         bc \
         bison \


### PR DESCRIPTION
Should fix failing ci builds like [14091483405 ](https://github.com/ClangBuiltLinux/tc-build/actions/runs/14091483405) and [14091491225](https://github.com/ClangBuiltLinux/tc-build/actions/runs/14091491225).