### PR TITLE
Add basic support for building Rust

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
       run: bash ci.sh deps
     - name: Build LLVM
       run: bash ci.sh llvm
+    - name: Build Rust
+      run: bash ci.sh rust
     - name: Build binutils
       run: bash ci.sh binutils
     - name: Build kernel

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ These scripts have been tested in a Docker image of the following distributions 
               lld \
               make \
               ninja-build \
+              pkg-config \
               python3-dev \
               texinfo \
               u-boot-tools \
@@ -183,6 +184,18 @@ bfd plugin: LLVM gold plugin has failed to create LTO module: Unknown attribute 
 ```
 
 Having a standalone copy of binutils (ideally in the same folder at the LLVM toolchain so that only one `PATH` modification is needed) works around this without any adverse side effects. Another workaround is bind mounting the new `LLVMgold.so` to `/usr/lib/LLVMgold.so`.
+
+## build-rust.py
+
+By default, `./build-rust.py` will clone Rust and build it using an LLVM previously built by `./build-llvm.py`, e.g.:
+
+```sh
+./build-llvm.py && ./build-rust.py
+```
+
+This script does not apply any Rust-specific patches to LLVM.
+
+Run `./build-rust.py -h` for more options and information.
 
 ## Contributing
 

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -9,7 +9,7 @@ import time
 
 import tc_build.utils
 
-from tc_build.llvm import LLVMBootstrapBuilder, LLVMBuilder, LLVMInstrumentedBuilder, LLVMSlimBuilder, LLVMSlimInstrumentedBuilder, LLVMSourceManager
+from tc_build.llvm import LLVMBootstrapBuilder, LLVMBuilder, LLVMInstrumentedBuilder, LLVMSlimBuilder, LLVMSlimInstrumentedBuilder, LLVMSourceManager, VALID_DISTRIBUTION_PROFILES
 from tc_build.kernel import KernelBuilder, LinuxSourceManager, LLVMKernelBuilder
 from tc_build.tools import HostTools, StageTools
 
@@ -158,6 +158,27 @@ parser.add_argument('-D',
 
                     '''),
                     nargs='+')
+parser.add_argument('--distribution-profile',
+                    help=textwrap.dedent('''\
+                    Smartly set value of LLVM_DISTRIBUTION_COMPONENTS for final build stage. Use in
+                    combination with
+
+                            --build-targets distribution
+                            --install-targets distribution
+
+                    to generate a smaller toolchain installation.
+
+                    Accepts the following values:
+
+                        none      - do not set LLVM_DISTRIBUTION_COMPONENTS at all
+                        bootstrap - components needed to build LLVM itself
+                        kernel    - components needed to build the Linux kernel
+
+                    The default is 'none' when '--full-toolchain' is enabled, 'kernel' if not.
+
+                    '''),
+                    type=str,
+                    choices=VALID_DISTRIBUTION_PROFILES)
 parser.add_argument('-f',
                     '--full-toolchain',
                     help=textwrap.dedent('''\
@@ -690,6 +711,8 @@ if args.pgo:
 final.build_targets = args.build_targets
 final.check_targets = args.check_targets
 final.cmake_defines.update(common_cmake_defines)
+if args.distribution_profile:
+    final.distribution_profile = args.distribution_profile
 final.folders.build = Path(build_folder, 'final')
 final.folders.install = Path(args.install_folder).resolve() if args.install_folder else None
 final.install_targets = args.install_targets

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -223,7 +223,7 @@ parser.add_argument('-l',
                     By default, the script will clone the llvm-project into the tc-build repo. If you have
                     another LLVM checkout that you would like to work out of, pass it to this parameter.
                     This can either be an absolute or relative path. Implies '--no-update'. When this
-                    option is supplied, '--ref' and '--use-good-revison' do nothing, as the script does
+                    option is supplied, '--ref' and '--use-good-revision' do nothing, as the script does
                     not manipulate a repository it does not own.
 
                     '''),

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -173,6 +173,7 @@ parser.add_argument('--distribution-profile',
                         none      - do not set LLVM_DISTRIBUTION_COMPONENTS at all
                         bootstrap - components needed to build LLVM itself
                         kernel    - components needed to build the Linux kernel
+                        rust      - components needed to build the Rust toolchain via build-rust.py
 
                     The default is 'none' when '--full-toolchain' is enabled, 'kernel' if not.
 

--- a/build-rust.py
+++ b/build-rust.py
@@ -84,7 +84,7 @@ parser.add_argument('-r',
                     does not own.
 
                     '''),
-                    default='master',
+                    default='main',
                     type=str)
 parser.add_argument('--show-build-commands',
                     help=textwrap.dedent('''\

--- a/build-rust.py
+++ b/build-rust.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# pylint: disable=invalid-name
+
+from argparse import ArgumentParser, RawTextHelpFormatter
+from pathlib import Path
+import textwrap
+import time
+
+import tc_build.utils
+
+from tc_build.rust import RustBuilder, RustSourceManager
+
+# This is a known good revision of Rust for building the kernel
+GOOD_REVISION = '69b3959afec9b5468d5de15133b199553f6e55d2'
+
+parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
+clone_options = parser.add_mutually_exclusive_group()
+
+parser.add_argument('--debug',
+                    help=textwrap.dedent('''\
+                    Build a debug compiler and standard library. This enables debug assertions,
+                    debug logging, overflow checks and debug info. The debug assertions and overflow
+                    checks can help catch issues when compiling.
+
+                    '''),
+                    action='store_true')
+parser.add_argument('-b',
+                    '--build-folder',
+                    help=textwrap.dedent('''\
+                    By default, the script will create a "build/rust" folder in the same folder as this
+                    script and build each requested stage within that containing folder. To change the
+                    location of the containing build folder, pass it to this parameter. This can be either
+                    an absolute or relative path. If it is provided, then a custom LLVM install folder
+                    needs to be provided as well to prevent mistakes.
+
+                    '''),
+                    type=str)
+parser.add_argument('-i',
+                    '--install-folder',
+                    help=textwrap.dedent('''\
+                    By default, the script will leave the toolchain in its build folder. To install it
+                    outside the build folder for persistent use, pass the installation location that you
+                    desire to this parameter. This can be either an absolute or relative path.
+
+                    '''),
+                    type=str)
+parser.add_argument('-l',
+                    '--llvm-install-folder',
+                    help=textwrap.dedent('''\
+                    By default, the script will try to use a built LLVM by './build-llvm.py'. To use
+                    another LLVM installation (perhaps from './build-llvm.py --install-folder'), pass
+                    it to this parameter.
+
+                    '''),
+                    type=str)
+parser.add_argument('-R',
+                    '--rust-folder',
+                    help=textwrap.dedent('''\
+                    By default, the script will clone the Rust project into the tc-build repo. If you have
+                    another Rust checkout that you would like to work out of, pass it to this parameter.
+                    This can either be an absolute or relative path. Implies '--no-update'. When this
+                    option is supplied, '--ref' and '--use-good-revision' do nothing, as the script does
+                    not manipulate a repository it does not own.
+
+                    '''),
+                    type=str)
+parser.add_argument('-n',
+                    '--no-update',
+                    help=textwrap.dedent('''\
+                    By default, the script always updates the Rust repo before building. This prevents
+                    that, which can be helpful during something like bisecting or manually managing the
+                    repo to pin it to a particular revision.
+
+                    '''),
+                    action='store_true')
+parser.add_argument('-r',
+                    '--ref',
+                    help=textwrap.dedent('''\
+                    By default, the script builds the main branch (tip of tree) of Rust. If you would
+                    like to build an older branch, use this parameter. This may be helpful in tracking
+                    down an older bug to properly bisect. This value is just passed along to 'git checkout'
+                    so it can be a branch name, tag name, or hash. This will have no effect if
+                    '--rust-folder' is provided, as the script does not manipulate a repository that it
+                    does not own.
+
+                    '''),
+                    default='master',
+                    type=str)
+parser.add_argument('--show-build-commands',
+                    help=textwrap.dedent('''\
+                    By default, the script only shows the output of the comands it is running. When this option
+                    is enabled, the invocations of the build tools will be shown to help with reproducing
+                    issues outside of the script.
+
+                    '''),
+                    action='store_true')
+clone_options.add_argument('--use-good-revision',
+                           help=textwrap.dedent('''\
+                    By default, the script updates Rust to the latest tip of tree revision, which may at times be
+                    broken or not work right. With this option, it will checkout a known good revision of Rust
+                    that builds and works properly. If you use this option often, please remember to update the
+                    script as the known good revision will change. This option may work best with a matching good
+                    revision used to build LLVM by './build-llvm.py'.
+
+                           '''),
+                           action='store_const',
+                           const=GOOD_REVISION,
+                           dest='ref')
+parser.add_argument('--vendor-string',
+                    help=textwrap.dedent('''\
+                    Add this value to the Rust version string (like "rustc ... (ClangBuiltLinux)"). Useful when
+                    reverting or applying patches on top of upstream Rust to differentiate a toolchain built
+                    with this script from upstream Rust or to distinguish a toolchain built with this script
+                    from the system's Rust. Defaults to ClangBuiltLinux, can be set to an empty string to
+                    override this and have no vendor in the version string.
+
+                    '''),
+                    type=str,
+                    default='ClangBuiltLinux')
+args = parser.parse_args()
+
+# Start tracking time that the script takes
+script_start = time.time()
+
+# Folder validation
+tc_build_folder = Path(__file__).resolve().parent
+src_folder = Path(tc_build_folder, 'src')
+
+if args.build_folder:
+    build_folder = Path(args.build_folder).resolve()
+
+    if not args.llvm_install_folder:
+        raise RuntimeError(
+            'Build folder customized, but no custom LLVM install folder provided -- this is likely a mistake. Provide both if you want to build in a custom folder?'
+        )
+else:
+    build_folder = Path(tc_build_folder, 'build/rust')
+
+if args.llvm_install_folder:
+    llvm_install_folder = Path(args.llvm_install_folder).resolve()
+else:
+    llvm_install_folder = Path(tc_build_folder, 'build/llvm/final')
+
+# Validate and configure Rust source
+if args.rust_folder:
+    if not (rust_folder := Path(args.rust_folder).resolve()).exists():
+        raise RuntimeError(f"Provided Rust folder ('{args.rust_folder}') does not exist?")
+else:
+    rust_folder = Path(src_folder, 'rust')
+rust_source = RustSourceManager(rust_folder)
+rust_source.download(args.ref)
+if not (args.rust_folder or args.no_update):
+    rust_source.update(args.ref)
+
+# Build Rust
+tc_build.utils.print_header('Building Rust')
+
+# Final build
+final = RustBuilder()
+final.folders.source = rust_folder
+final.folders.build = Path(build_folder, 'final')
+final.folders.install = Path(args.install_folder).resolve() if args.install_folder else None
+final.llvm_install_folder = llvm_install_folder
+final.debug = args.debug
+final.vendor_string = args.vendor_string
+final.show_commands = args.show_build_commands
+
+final.configure()
+final.build()
+final.show_install_info()
+
+print(f"Script duration: {tc_build.utils.get_duration(script_start)}")

--- a/ci.sh
+++ b/ci.sh
@@ -9,7 +9,7 @@ set -eu
 function parse_parameters() {
     while (($#)); do
         case $1 in
-            all | binutils | deps | kernel | llvm) action=$1 ;;
+            all | binutils | deps | kernel | llvm | rust) action=$1 ;;
             *) exit 33 ;;
         esac
         shift
@@ -19,6 +19,7 @@ function parse_parameters() {
 function do_all() {
     do_deps
     do_llvm
+    do_rust
     do_binutils
     do_kernel
 }
@@ -54,6 +55,7 @@ function do_deps() {
         lld \
         make \
         ninja-build \
+        pkg-config \
         python3 \
         texinfo \
         xz-utils \
@@ -110,6 +112,14 @@ function do_llvm() {
         --show-build-commands \
         --targets X86 \
         "${extra_args[@]}"
+}
+
+function do_rust() {
+    "$base"/build-rust.py \
+        --debug \
+        --llvm-install-folder "$install" \
+        --install-folder "$install" \
+        --show-build-commands
 }
 
 parse_parameters "$@"

--- a/ci.sh
+++ b/ci.sh
@@ -100,6 +100,7 @@ function do_llvm() {
         --build-stage1-only \
         --build-target distribution \
         --check-targets clang lld llvm \
+        --distribution-profile rust \
         --install-folder "$install" \
         --install-target distribution \
         --projects clang lld \

--- a/tc_build/builder.py
+++ b/tc_build/builder.py
@@ -32,6 +32,12 @@ class Builder:
             else:
                 self.folders.build.unlink()
 
+    def make_build_folder(self):
+        if not self.folders.build:
+            raise RuntimeError('No build folder set?')
+
+        self.folders.build.mkdir(parents=True)
+
     def run_cmd(self, cmd, capture_output=False, cwd=None):
         if self.show_commands:
             # Acts sort of like 'set -x' in bash

--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -290,16 +290,6 @@ class LLVMBuilder(Builder):
 
         if self.tools.ar:
             self.cmake_defines['CMAKE_AR'] = self.tools.ar
-        # Utilize thin archives to save space. Use the deprecated -T for
-        # compatibility with binutils<2.38 and llvm-ar<14. Unfortunately, thin
-        # archives make compiler-rt archives not easily distributable, so we
-        # disable the optimization when compiler-rt is enabled and there is an
-        # install directory. Ideally thin archives should still be usable for
-        # non-compiler-rt projects.
-        if not (self.folders.install and self.project_is_enabled('compiler-rt')):
-            self.cmake_defines['CMAKE_CXX_ARCHIVE_CREATE'] = '<CMAKE_AR> DqcT <TARGET> <OBJECTS>'
-        self.cmake_defines['CMAKE_CXX_ARCHIVE_FINISH'] = 'true'
-
         if self.tools.ranlib:
             self.cmake_defines['CMAKE_RANLIB'] = self.tools.ranlib
         if 'CMAKE_BUILD_TYPE' not in self.cmake_defines:

--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -13,6 +13,7 @@ from tc_build.source import GitSourceManager
 import tc_build.utils
 
 LLVM_VER_FOR_RUNTIMES = 20
+VALID_DISTRIBUTION_PROFILES = ('none', 'bootstrap', 'kernel')
 
 
 def get_all_targets(llvm_folder, experimental=False):
@@ -57,6 +58,7 @@ class LLVMBuilder(Builder):
             # it and limits optimization opportunities for LTO, PGO, and BOLT.
             'LLVM_LINK_LLVM_DYLIB': 'OFF',
         }
+        self.distribution_profile = 'none'
         self.install_targets = []
         self.llvm_major_version = 0
         self.tools = None
@@ -370,10 +372,84 @@ class LLVMBuilder(Builder):
                                                    text=True).stdout.strip()
             self.cmake_defines['LLVM_DEFAULT_TARGET_TRIPLE'] = default_target_triple
 
+        self.handle_distribution_profile()
+
         cmake_cmd += [f'-D{key}={self.cmake_defines[key]}' for key in sorted(self.cmake_defines)]
 
         self.clean_build_folder()
         self.run_cmd(cmake_cmd)
+
+    def handle_distribution_profile(self):
+        if self.distribution_profile == 'none':
+            return
+        if self.distribution_profile not in VALID_DISTRIBUTION_PROFILES:
+            raise RuntimeError(f"Unknown distribution profile: {self.distribution_profile}")
+
+        self.set_llvm_major_version()
+
+        llvm_build_runtime = self.cmake_defines.get('LLVM_BUILD_RUNTIME', 'ON') == 'ON'
+        build_compiler_rt = self.project_is_enabled('compiler-rt') and llvm_build_runtime
+        llvm_build_tools = self.cmake_defines.get('LLVM_BUILD_TOOLS', 'ON') == 'ON'
+
+        distribution_components = []
+        runtime_distribution_components = []
+
+        # There are two distribution profiles.
+        # bootstrap: Used for stage one to build the rest of LLVM
+        # kernel: All tools used to build the kernel
+        # For the most part, bootstrap is a subset of kernel, aside from the
+        # tools and libraries for building an instrumented compiler.
+        if llvm_build_tools:
+            distribution_components += [
+                'llvm-ar',
+                'llvm-ranlib',
+            ]
+            if self.distribution_profile == 'kernel':
+                distribution_components += [
+                    'llvm-nm',
+                    'llvm-objcopy',
+                    'llvm-objdump',
+                    'llvm-readelf',
+                    'llvm-strip',
+                ]
+            # If multicall is enabled, we need to add all possible tools to the
+            # distribution components list to prevent them from being built as
+            # standalone tools, which may break the build for tools like
+            # llvm-symbolizer because they need LLVMDebuginfod but it is not
+            # linked in that configuration. While this does build a little more
+            # code for the 'distribution' target, it should result in only a
+            # slight increase in installation size due to being a multicall
+            # binary.
+            if self.multicall_is_enabled():
+                distribution_components += [
+                    item for item in self.llvm_driver_binaries('llvm')
+                    if item not in distribution_components
+                ]
+        if self.project_is_enabled('bolt'):
+            distribution_components.append('bolt')
+        if self.project_is_enabled('clang'):
+            distribution_components += ['clang', 'clang-resource-headers']
+            if self.multicall_is_enabled():
+                distribution_components += [
+                    item for item in self.llvm_driver_binaries('clang')
+                    if item not in distribution_components
+                ]
+        if self.project_is_enabled('lld'):
+            distribution_components.append('lld')
+
+        if self.distribution_profile == 'bootstrap' and build_compiler_rt:
+            distribution_components.append('llvm-profdata')
+            if self.llvm_major_version >= LLVM_VER_FOR_RUNTIMES:
+                distribution_components.append('runtimes')
+                runtime_distribution_components.append('profile')
+            else:
+                distribution_components.append('profile')
+
+        if distribution_components:
+            self.cmake_defines['LLVM_DISTRIBUTION_COMPONENTS'] = ';'.join(distribution_components)
+        if runtime_distribution_components:
+            self.cmake_defines['LLVM_RUNTIME_DISTRIBUTION_COMPONENTS'] = ';'.join(
+                runtime_distribution_components)
 
     def host_target(self):
         uname_to_llvm = {
@@ -481,6 +557,11 @@ class LLVMBuilder(Builder):
 
 class LLVMSlimBuilder(LLVMBuilder):
 
+    def __init__(self):
+        super().__init__()
+
+        self.distribution_profile = 'kernel'
+
     def configure(self):
         # yapf: disable
         slim_clang_defines = {
@@ -503,54 +584,7 @@ class LLVMSlimBuilder(LLVMBuilder):
         if arcmt_cmakelists.exists():
             slim_clang_defines['CLANG_ENABLE_ARCMT'] = 'OFF'
 
-        llvm_build_runtime = self.cmake_defines.get('LLVM_BUILD_RUNTIME', 'ON') == 'ON'
-        build_compiler_rt = self.project_is_enabled('compiler-rt') and llvm_build_runtime
-
-        llvm_build_tools = self.cmake_defines.get('LLVM_BUILD_TOOLS', 'ON') == 'ON'
-
-        self.set_llvm_major_version()
-
-        distribution_components = []
-        runtime_distribution_components = []
-        if llvm_build_tools:
-            distribution_components += [
-                'llvm-ar',
-                'llvm-nm',
-                'llvm-objcopy',
-                'llvm-objdump',
-                'llvm-ranlib',
-                'llvm-readelf',
-                'llvm-strip',
-            ]
-            # If multicall is enabled, we need to add all possible tools to the
-            # distribution components list to prevent them from being built as
-            # standalone tools, which may break the build for tools like
-            # llvm-symbolizer because they need LLVMDebuginfod but it is not
-            # linked in that configuration. While this does build a little more
-            # code for the 'distribution' target, it should result in only a
-            # slight increase in installation size due to being a multicall
-            # binary.
-            if self.multicall_is_enabled():
-                distribution_components += [item for item in self.llvm_driver_binaries('llvm') if item not in distribution_components]
-        if self.project_is_enabled('bolt'):
-            distribution_components.append('bolt')
-        if self.project_is_enabled('clang'):
-            distribution_components += ['clang', 'clang-resource-headers']
-            if self.multicall_is_enabled():
-                distribution_components += [item for item in self.llvm_driver_binaries('clang') if item not in distribution_components]
-        if self.project_is_enabled('lld'):
-            distribution_components.append('lld')
-        if build_compiler_rt:
-            distribution_components.append('llvm-profdata')
-            if self.llvm_major_version >= LLVM_VER_FOR_RUNTIMES:
-                distribution_components.append('runtimes')
-                runtime_distribution_components.append('profile')
-            else:
-                distribution_components.append('profile')
-
         slim_llvm_defines = {
-            # Tools needed by bootstrapping
-            'LLVM_DISTRIBUTION_COMPONENTS': ';'.join(distribution_components),
             # Don't build bindings; they are for other languages that the kernel does not use
             'LLVM_ENABLE_BINDINGS': 'OFF',
             # Don't build Ocaml documentation
@@ -562,8 +596,6 @@ class LLVMSlimBuilder(LLVMBuilder):
             # Don't include example build targets to save on cmake cycles
             'LLVM_INCLUDE_EXAMPLES': 'OFF',
         }
-        if runtime_distribution_components:
-            slim_llvm_defines['LLVM_RUNTIME_DISTRIBUTION_COMPONENTS'] = ';'.join(runtime_distribution_components)
 
         slim_compiler_rt_defines = {
             # Don't build libfuzzer when compiler-rt is enabled, it invokes cmake again and we don't use it
@@ -578,6 +610,10 @@ class LLVMSlimBuilder(LLVMBuilder):
         self.cmake_defines.update(slim_llvm_defines)
         if self.project_is_enabled('clang'):
             self.cmake_defines.update(slim_clang_defines)
+
+        llvm_build_runtime = self.cmake_defines.get('LLVM_BUILD_RUNTIME', 'ON') == 'ON'
+        build_compiler_rt = self.project_is_enabled('compiler-rt') and llvm_build_runtime
+
         if build_compiler_rt:
             self.cmake_defines.update(slim_compiler_rt_defines)
 
@@ -589,6 +625,7 @@ class LLVMBootstrapBuilder(LLVMSlimBuilder):
     def __init__(self):
         super().__init__()
 
+        self.distribution_profile = 'bootstrap'
         self.projects = ['clang', 'lld']
         self.targets = ['host']
 

--- a/tc_build/rust.py
+++ b/tc_build/rust.py
@@ -51,6 +51,7 @@ class RustBuilder(Builder):
             '--release-description', self.vendor_string,
             '--disable-docs',
             '--enable-locked-deps',
+            '--enable-verbose-configure',
             '--tools', 'cargo,clippy,rustdoc,rustfmt,src',
             '--prefix', install_folder,
             '--sysconfdir', 'etc',

--- a/tc_build/rust.py
+++ b/tc_build/rust.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import subprocess
+import time
+
+from tc_build.builder import Builder
+from tc_build.source import GitSourceManager
+import tc_build.utils
+
+
+class RustBuilder(Builder):
+
+    def __init__(self):
+        super().__init__()
+
+        self.llvm_install_folder = None
+        self.debug = False
+        self.vendor_string = ''
+
+    def build(self):
+        if not self.folders.build:
+            raise RuntimeError('No build folder set for build()?')
+        if not Path(self.folders.build, 'bootstrap.toml').exists():
+            raise RuntimeError('No bootstrap.toml in build folder, run configure()?')
+
+        build_start = time.time()
+        self.run_cmd([Path(self.folders.source, 'x.py'), 'install'], cwd=self.folders.build)
+
+        tc_build.utils.print_info(f"Build duration: {tc_build.utils.get_duration(build_start)}")
+
+        if self.folders.install:
+            tc_build.utils.create_gitignore(self.folders.install)
+
+    def configure(self):
+        if not self.llvm_install_folder:
+            raise RuntimeError('No LLVM install folder set?')
+        if not self.folders.source:
+            raise RuntimeError('No source folder set?')
+        if not self.folders.build:
+            raise RuntimeError('No build folder set?')
+
+        # Configure the build
+        #
+        # 'codegen-tests' requires '-DLLVM_INSTALL_UTILS=ON'.
+        install_folder = self.folders.install if self.folders.install else self.folders.build
+
+        # yapf: disable
+        configure_cmd = [
+            Path(self.folders.source, 'configure'),
+            '--release-description', self.vendor_string,
+            '--disable-docs',
+            '--enable-locked-deps',
+            '--tools', 'cargo,clippy,rustdoc,rustfmt,src',
+            '--prefix', install_folder,
+            '--sysconfdir', 'etc',
+            '--disable-codegen-tests',
+            '--disable-lld',
+            '--disable-llvm-bitcode-linker',
+            '--llvm-root', self.llvm_install_folder,
+        ]
+        # yapf: enable
+
+        if self.debug:
+            configure_cmd.append('--enable-debug')
+
+        self.clean_build_folder()
+        self.make_build_folder()
+        self.run_cmd(configure_cmd, cwd=self.folders.build)
+
+    def show_install_info(self):
+        # Installation folder is optional, show build folder as the
+        # installation location in that case.
+        install_folder = self.folders.install if self.folders.install else self.folders.build
+        if not install_folder:
+            raise RuntimeError('Installation folder not set?')
+        if not install_folder.exists():
+            raise RuntimeError('Installation folder does not exist, run build()?')
+        if not (bin_folder := Path(install_folder, 'bin')).exists():
+            raise RuntimeError('bin folder does not exist in installation folder, run build()?')
+
+        tc_build.utils.print_header('Rust installation information')
+        install_info = (f"Toolchain is available at: {install_folder}\n\n"
+                        'To use, either run:\n\n'
+                        f"\t$ export PATH={bin_folder}:$PATH\n\n"
+                        'or add:\n\n'
+                        f"\tPATH={bin_folder}:$PATH\n\n"
+                        'before the command you want to use this toolchain.\n')
+        print(install_info)
+
+        for tool in ['rustc', 'rustdoc', 'rustfmt', 'clippy-driver', 'cargo']:
+            if (binary := Path(bin_folder, tool)).exists():
+                subprocess.run([binary, '--version', '--verbose'], check=True)
+                print()
+        tc_build.utils.flush_std_err_out()
+
+
+class RustSourceManager(GitSourceManager):
+
+    def __init__(self, repo):
+        super().__init__(repo)
+
+        self._pretty_name = 'Rust'
+        self._repo_url = 'https://github.com/rust-lang/rust.git'


### PR DESCRIPTION
There a lot of options missing and it does not do any fancy kind of build. But it is a start, and it is already useful, e.g. Peter could have used it to test the new KCFI arity flag that requires LLVM 21 but upstream Rust still uses LLVM 20. It could also be useful to potentially/eventually have LLVM+Rust builds in kernel.org that use the exact same LLVM build.

I took the approach that the new script only takes care of building Rust provided an existing LLVM, which seemed simple and clear.

Thus add the basic infrastructure, plus a bit of documentation. Add it to the CI, too.

I successfully built it in a clean Debian 12 and Fedora 41.

A few notes:

  - The script works on its own, but the CI does not pass because `llvm-config --bindir` does not work with the set of flags used in CI for LLVM -- we are missing at least `llvm-config` in the distribution components of the LLVM step, but then also headers like `llvm/Config/llvm-config.h`.

    I am not sure how far you would want to modify the LLVM side or the `do_llvm()` step, so I decided to send this with the failing CI so that you see it.

  - If `LLVM_INSTALL_UTILS` is enabled (to get `FileCheck` installed, which is used by the Rust build system for testing), then we can leave `codegen-tests` to its default (enabled) in the Rust configuration.

    But perhaps we want to leave those tests anyway as the equivalent of the `check-*`s in LLVM, i.e. disabled by default even if the Rust configuration enables them by default, and let the user enable them.

  - Rust uses submodules and so on and manages them on its own if allowed, so I just did that. I didn't add/test shallow clones, so I didn't add them.

  - This does nothing about the LLVM patches that Rust may carry (until they get upstreamed). One could use `--rust-folder` to point to a checkout of the branch that Rust uses, and perhaps we should add some documentation about it, or even provide an option in `./build-llvm.py` to build such a branch, but I didn't try/test anything related to that yet.

  - We probably want to offer eventually `--quiet-x`, `--no-locked-deps`, `--tools`, `--codegen-tests`, `--docs`, etc.

  - After this, we could add a `--build-bindgen` here or perhaps a new `./build-bindgen.py`, so that we can easily get a full toolchain for the kernel. It is really just a one liner once one has the Rust toolchain, so it is not too important.

  - Some refactoring could be done so that both `./build-llvm.py` and `./build-rust.py` reuse certain bits, e.g. `show_install_info()`.

I tried to follow the LLVM script as closely as possible and "copy" the style etc., but there may be mistakes -- please feel free to take this and modify it as you see fit, of course.

I hope this helps!

Cc: Peter Zijlstra (by email)