### PR TITLE
Adjust the base LLVM configuration

### DIFF
--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -32,7 +32,10 @@ class LLVMBuilder(Builder):
         self.build_targets = ['all']
         self.ccache = False
         self.check_targets = []
-        self.cmake_defines = {}
+        self.cmake_defines = {
+            # Reduce dynamic dependencies
+            'LLVM_ENABLE_LIBXML2': 'OFF',
+        }
         self.install_targets = []
         self.llvm_major_version = 0
         self.tools = None

--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -35,6 +35,10 @@ class LLVMBuilder(Builder):
         self.cmake_defines = {
             # Reduce dynamic dependencies
             'LLVM_ENABLE_LIBXML2': 'OFF',
+            # While this option reduces build resources and disk space, it
+            # increases start up time for the tools dynamically linked against
+            # it and limits optimization opportunities for LTO, PGO, and BOLT.
+            'LLVM_LINK_LLVM_DYLIB': 'OFF',
         }
         self.install_targets = []
         self.llvm_major_version = 0


### PR DESCRIPTION
This turns off linking against libxml2 by default and makes sure that we do not dynamically link against the LLVM libraries. See the commit messages for the individual details.
