### PR TITLE
build-llvm.py: Add ability to override "true" arguments

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -13,6 +13,14 @@ from tc_build.llvm import LLVMBootstrapBuilder, LLVMBuilder, LLVMInstrumentedBui
 from tc_build.kernel import KernelBuilder, LinuxSourceManager, LLVMKernelBuilder
 from tc_build.tools import HostTools, StageTools
 
+try:
+    # pylint: disable-next=ungrouped-imports
+    from argparse import BooleanOptionalAction
+    # 'store_true' sets 'default' implicitly, do it explicitly to match
+    BOOL_ARGS = {'action': BooleanOptionalAction, 'default': False}
+except ImportError:
+    BOOL_ARGS = {'action': 'store_true'}
+
 # This is a known good revision of LLVM for building the kernel
 GOOD_REVISION = 'd5802c30ae6cf296489daf12b36582e9e1d658bb'
 
@@ -29,7 +37,7 @@ parser.add_argument('--assertions',
                     issues when compiling but it will increase compile times by 15-20%%.
 
                     '''),
-                    action='store_true')
+                    **BOOL_ARGS)
 parser.add_argument('-b',
                     '--build-folder',
                     help=textwrap.dedent('''\


### PR DESCRIPTION
Users (such as myself) may have wrappers around `build-llvm.py` to set default arguments but allow additional arguments to be passed. Arguments that take a value can be overridden by subsequent instances of the arguments but boolean actions cannot.

Python 3.9 introduced the `BooleanOptionalAction` action in the `argparse` package, which automatically defines `--foo` and `--no-foo`, which would allow one to override `--assertions` with `--no-assertions` for that one invocation.

For now, start with `--no-assertions`, as the presence of the `--no-` value for the other boolean options is noisy and they are unlikely to defaulted to with the need to override. This change can be done to options as use cases appear.
