### PR TITLE
tc_build: kernel: Use virtconfig for arm64 profiling target

### DIFF
--- a/tc_build/kernel.py
+++ b/tc_build/kernel.py
@@ -408,7 +408,14 @@ class LLVMKernelBuilder(Builder):
         # requested.
         for config_target, llvm_targets in self.matrix.items():
             for llvm_target in llvm_targets:
-                if config_target == 'defconfig' and llvm_target == 'ARM':
+                if config_target == 'defconfig' and llvm_target == 'AArch64':
+                    builder = allconfig_capable_builders[llvm_target]()
+                    # For arm64, defconfig is quite large. To be quicker and
+                    # not use as much space for profiling data, use
+                    # 'virtconfig'.
+                    builder.config_targets = ['virtconfig']
+                    builders.append(builder)
+                elif config_target == 'defconfig' and llvm_target == 'ARM':
                     builders += [
                         ArmV5KernelBuilder(),
                         ArmV6KernelBuilder(),


### PR DESCRIPTION
arm64 defconfig is quite large relative to other defconfigs, which makes it take longer to build than most other architectures and makes profiling data consume much more space.

virtconfig was introduced in 6.3 to turn off a lot of code that will not run under a virtual machine, slimming up the build configuration and making it faster. Measuring on two different machines, virtconfig is 50% faster to build than defconfig.

    Benchmark 1: virtconfig
      Time (mean ± σ):     120.938 s ±  0.707 s    [User: 6864.867 s, System: 910.128 s]
      Range (min … max):   120.413 s … 121.742 s    3 runs

    Benchmark 2: defconfig
      Time (mean ± σ):     180.490 s ±  0.271 s    [User: 10490.721 s, System: 1470.871 s]
      Range (min … max):   180.210 s … 180.751 s    3 runs

    Summary
      virtconfig ran
        1.49 ± 0.01 times faster than defconfig

    Benchmark 1: virtconfig
      Time (mean ± σ):     275.814 s ±  0.256 s    [User: 3800.242 s, System: 452.871 s]
      Range (min … max):   275.640 s … 276.107 s    3 runs

    Benchmark 2: defconfig
      Time (mean ± σ):     418.275 s ±  0.061 s    [User: 5773.311 s, System: 725.536 s]
      Range (min … max):   418.206 s … 418.324 s    3 runs

    Summary
      virtconfig ran
        1.52 ± 0.00 times faster than defconfig

Switch to virtconfig unconditionally, as kernel.py requires 6.9 or newer, so it will always be available.
