### PR TITLE
tc_build: Enable '--conservative-instrumentation' for BOLT on Apple Silicon

### DIFF
--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -78,6 +78,13 @@ class LLVMBuilder(Builder):
                 clang_inst,
                 clang,
             ]
+            # When running an instrumented binary on certain platforms (namely
+            # Apple Silicon), there may be hangs due to instrumentation in
+            # between exclusive load and store instructions:
+            # https://github.com/llvm/llvm-project/issues/153492
+            # Enable conservative instrumentation to avoid this.
+            if tc_build.utils.cpu_is_apple_silicon():
+                clang_inst_cmd.append('--conservative-instrumentation')
             self.run_cmd(clang_inst_cmd)
 
             self.bolt_builder.bolt_instrumentation = True

--- a/tc_build/utils.py
+++ b/tc_build/utils.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python3
 
+from pathlib import Path
 import subprocess
 import sys
+import re
 import time
+
+
+def cpu_is_apple_silicon():
+    cpuinfo = Path('/proc/cpuinfo').read_text(encoding='utf-8')
+    if match := re.search(r"implementer\s+:\s+(\w+)", cpuinfo):
+        # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/arm64/include/asm/cputype.h?h=v6.17-rc4#n62
+        return match.groups()[0] == '0x61'
+    # If we cannot prove that it is Apple Silicon, we assume it is not
+    return False
 
 
 def create_gitignore(folder):


### PR DESCRIPTION
When performing BOLT on Apple Silicon (such as when building in a UTM virtual machine), running clang hangs due to instrumentation between exclusive load and store instructions (see the LLVM issue linked in the comments for more information).

Detect when running on Apple Silicon and enable the conservative instrumentation option to avoid hitting this issue.
