### PR TITLE
Update PGO kernel to 6.17 and bump known good revision

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -25,7 +25,7 @@ except ImportError:
 GOOD_REVISION = 'd5802c30ae6cf296489daf12b36582e9e1d658bb'
 
 # The version of the Linux kernel that the script downloads if necessary
-DEFAULT_KERNEL_FOR_PGO = (6, 16, 0)
+DEFAULT_KERNEL_FOR_PGO = (6, 17, 0)
 
 parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
 clone_options = parser.add_mutually_exclusive_group()

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -22,7 +22,7 @@ except ImportError:
     BOOL_ARGS = {'action': 'store_true'}
 
 # This is a known good revision of LLVM for building the kernel
-GOOD_REVISION = 'd5802c30ae6cf296489daf12b36582e9e1d658bb'
+GOOD_REVISION = '3c0f7b184d265281dfcd4fab73348bc0e72c9902'
 
 # The version of the Linux kernel that the script downloads if necessary
 DEFAULT_KERNEL_FOR_PGO = (6, 17, 0)


### PR DESCRIPTION
This has been lightly qualified on an aarch64 and x86_64 host with the environment and configuration that I build the kernel.org toolchains with.
