### PR TITLE
build-rust.py: Introduce '--configure-set-args'

### DIFF
--- a/build-rust.py
+++ b/build-rust.py
@@ -35,6 +35,23 @@ parser.add_argument('-b',
 
                     '''),
                     type=str)
+parser.add_argument('-c',
+                    '--configure-set-args',
+                    help=textwrap.dedent('''\
+                    Pass the provided values to configure via the '--set' argument.
+
+                    For example:
+
+                        --configure-set-args build.foo=false build.bar=true
+
+                    would pass
+
+                        --set build.foo=false --set build.bar=true
+
+                    to configure.
+
+                    '''),
+                    nargs='+')
 parser.add_argument('-i',
                     '--install-folder',
                     help=textwrap.dedent('''\
@@ -161,6 +178,8 @@ final.folders.source = rust_folder
 final.folders.build = Path(build_folder, 'final')
 final.folders.install = Path(args.install_folder).resolve() if args.install_folder else None
 final.llvm_install_folder = llvm_install_folder
+if args.configure_set_args:
+    final.configure_set_args += args.configure_set_args
 final.debug = args.debug
 final.vendor_string = args.vendor_string
 final.show_commands = args.show_build_commands

--- a/tc_build/rust.py
+++ b/tc_build/rust.py
@@ -14,6 +14,7 @@ class RustBuilder(Builder):
     def __init__(self):
         super().__init__()
 
+        self.configure_set_args = []
         self.llvm_install_folder = None
         self.debug = False
         self.vendor_string = ''
@@ -64,6 +65,9 @@ class RustBuilder(Builder):
 
         if self.debug:
             configure_cmd.append('--enable-debug')
+
+        for val in self.configure_set_args:
+            configure_cmd += ['--set', val]
 
         self.clean_build_folder()
         self.make_build_folder()


### PR DESCRIPTION
To give end users more flexibility in configuring their toolchain. This mirrors the `build-llvm.py` `--defines` option.

For example, this will allow me to build Rust using my custom environment for the kernel.org toolchains:

https://github.com/nathanchance/env/blob/8997cea59354fbe02e117100148ea48bd6ee88b3/python/pgo-llvm-builder/build.py#L411-L422
