### PR TITLE
tc-build: Switch to ruff for Python formatting

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,3 +1,0 @@
-[style]
-based_on_style = pep8
-column_limit = 100

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Run `./build-rust.py -h` for more options and information.
 
 This repository openly welcomes pull requests! There are a few presubmit checks that run to make sure the code stays consistently formatted and free of bugs.
 
-1. All Python files must be passed through [`ruff`](https://github.com/astral-sh/ruff) for linting and [`yapf`](https://github.com/google/yapf) for style.
+1. All Python files must be passed through [`ruff`](https://github.com/astral-sh/ruff) for linting and style via `ruff check .` and `ruff format .`.
 
 2. All shell files must be passed through [`shellcheck`](https://github.com/koalaman/shellcheck) for linting and [`shfmt`](https://github.com/mvdan/sh) (specifically `shfmt -ci -i 4 -w`) for style.
 

--- a/build-binutils.py
+++ b/build-binutils.py
@@ -11,51 +11,62 @@ import tc_build.utils
 LATEST_BINUTILS_RELEASE = (2, 46, 0)
 
 parser = ArgumentParser()
-parser.add_argument('-B',
-                    '--binutils-folder',
-                    help='''
+parser.add_argument(
+    '-B',
+    '--binutils-folder',
+    help='''
                     By default, the script will download a copy of the binutils source in the src folder within
                     the same folder as this script. If you have your own copy of the binutils source that you
                     would like to build from, pass it to this parameter. It can be either an absolute or
                     relative path.
                     ''',
-                    type=str)
-parser.add_argument('-b',
-                    '--build-folder',
-                    help='''
+    type=str,
+)
+parser.add_argument(
+    '-b',
+    '--build-folder',
+    help='''
                     By default, the script will create a "build/binutils" folder in the same folder as this
                     script then build each target in its own folder within that containing folder. If you
                     would like the containing build folder to be somewhere else, pass it to this parameter.
                     that done somewhere else, pass it to this parameter. It can be either an absolute or
                     relative path.
                     ''',
-                    type=str)
-parser.add_argument('-i',
-                    '--install-folder',
-                    help='''
+    type=str,
+)
+parser.add_argument(
+    '-i',
+    '--install-folder',
+    help='''
                     By default, the script will build binutils but stop before installing it. To install
                     them into a prefix, pass it to this parameter. This can be either an absolute or
                     relative path.
                     ''',
-                    type=str)
-parser.add_argument('-m',
-                    '--march',
-                    metavar='ARCH',
-                    help='''
+    type=str,
+)
+parser.add_argument(
+    '-m',
+    '--march',
+    metavar='ARCH',
+    help='''
                     Add -march=ARCH to CFLAGS to optimize the toolchain for the processor that it will be
                     running on.
                     ''',
-                    type=str)
-parser.add_argument('--show-build-commands',
-                    help='''
+    type=str,
+)
+parser.add_argument(
+    '--show-build-commands',
+    help='''
                     By default, the script only shows the output of the comands it is running. When this option
                     is enabled, the invocations of configure and make will be shown to help with reproducing
                     issues outside of the script.
                     ''',
-                    action='store_true')
-parser.add_argument('-t',
-                    '--targets',
-                    help='''
+    action='store_true',
+)
+parser.add_argument(
+    '-t',
+    '--targets',
+    help='''
                     The script can build binutils targeting arm-linux-gnueabi, aarch64-linux-gnu,
                     mips-linux-gnu, mipsel-linux-gnu, powerpc-linux-gnu, powerpc64-linux-gnu,
                     powerpc64le-linux-gnu, riscv64-linux-gnu, s390x-linux-gnu, and x86_64-linux-gnu.
@@ -64,7 +75,8 @@ parser.add_argument('-t',
                     specific targets only, pass them to this script. It can be either the full target
                     or just the first part (arm, aarch64, x86_64, etc).
                     ''',
-                    nargs='+')
+    nargs='+',
+)
 args = parser.parse_args()
 
 script_start = time.time()

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -9,13 +9,22 @@ import time
 
 import tc_build.utils
 
-from tc_build.llvm import LLVMBootstrapBuilder, LLVMBuilder, LLVMInstrumentedBuilder, LLVMSlimBuilder, LLVMSlimInstrumentedBuilder, LLVMSourceManager, VALID_DISTRIBUTION_PROFILES
+from tc_build.llvm import (
+    LLVMBootstrapBuilder,
+    LLVMBuilder,
+    LLVMInstrumentedBuilder,
+    LLVMSlimBuilder,
+    LLVMSlimInstrumentedBuilder,
+    LLVMSourceManager,
+    VALID_DISTRIBUTION_PROFILES,
+)
 from tc_build.kernel import KernelBuilder, LinuxSourceManager, LLVMKernelBuilder
 from tc_build.tools import HostTools, StageTools
 
 try:
     # pylint: disable-next=ungrouped-imports
     from argparse import BooleanOptionalAction
+
     # 'store_true' sets 'default' implicitly, do it explicitly to match
     BOOL_ARGS = {'action': BooleanOptionalAction, 'default': False}
 except ImportError:
@@ -31,26 +40,31 @@ parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
 clone_options = parser.add_mutually_exclusive_group()
 opt_options = parser.add_mutually_exclusive_group()
 
-parser.add_argument('--assertions',
-                    help=textwrap.dedent('''\
+parser.add_argument(
+    '--assertions',
+    help=textwrap.dedent('''\
                     In a release configuration, assertions are not enabled. Assertions can help catch
                     issues when compiling but it will increase compile times by 15-20%%.
 
                     '''),
-                    **BOOL_ARGS)
-parser.add_argument('-b',
-                    '--build-folder',
-                    help=textwrap.dedent('''\
+    **BOOL_ARGS,
+)
+parser.add_argument(
+    '-b',
+    '--build-folder',
+    help=textwrap.dedent('''\
                     By default, the script will create a "build/llvm" folder in the same folder as this
                     script and build each requested stage within that containing folder. To change the
                     location of the containing build folder, pass it to this parameter. This can be either
                     an absolute or relative path.
 
                     '''),
-                    type=str)
-parser.add_argument('--build-targets',
-                    default=['all'],
-                    help=textwrap.dedent('''\
+    type=str,
+)
+parser.add_argument(
+    '--build-targets',
+    default=['all'],
+    help=textwrap.dedent('''\
                     By default, the 'all' target is used as the build target for the final stage. With
                     this option, targets such as 'distribution' could be used to generate a slimmer
                     toolchain or targets such as 'clang' or 'llvm-ar' could be used to just test building
@@ -58,9 +72,11 @@ parser.add_argument('--build-targets',
 
                     NOTE: This only applies to the final stage build to avoid complicating tc-build internals.
                     '''),
-                    nargs='+')
-parser.add_argument('--bolt',
-                    help=textwrap.dedent('''\
+    nargs='+',
+)
+parser.add_argument(
+    '--bolt',
+    help=textwrap.dedent('''\
                     Optimize the final clang binary with BOLT (Binary Optimization and Layout Tool), which can
                     often improve compile time performance by 5-7%% on average.
 
@@ -107,9 +123,11 @@ parser.add_argument('--bolt',
                                 or run build-llvm.py without '--bolt'.
 
                     '''),
-                    action='store_true')
-opt_options.add_argument('--build-stage1-only',
-                         help=textwrap.dedent('''\
+    action='store_true',
+)
+opt_options.add_argument(
+    '--build-stage1-only',
+    help=textwrap.dedent('''\
                     By default, the script does a multi-stage build: it builds a more lightweight version of
                     LLVM first (stage 1) then uses that build to build the full toolchain (stage 2). This
                     is also known as bootstrapping.
@@ -119,8 +137,9 @@ opt_options.add_argument('--build-stage1-only',
                     use. However, if your system is slow or can't handle 2+ stage builds, you may need this flag.
 
                          '''),
-                         action='store_true')
-# yapf: disable
+    action='store_true',
+)
+# fmt: off
 parser.add_argument('--build-type',
                     metavar='BUILD_TYPE',
                     help=textwrap.dedent('''\
@@ -133,9 +152,10 @@ parser.add_argument('--build-type',
                     '''),
                     type=str,
                     choices=['Release', 'Debug', 'RelWithDebInfo', 'MinSizeRel'])
-# yapf: enable
-parser.add_argument('--check-targets',
-                    help=textwrap.dedent('''\
+# fmt: on
+parser.add_argument(
+    '--check-targets',
+    help=textwrap.dedent('''\
                     By default, no testing is run on the toolchain. If you would like to run unit/regression
                     tests, use this parameter to specify a list of check targets to run with ninja. Common
                     ones include check-llvm, check-clang, and check-lld.
@@ -145,10 +165,12 @@ parser.add_argument('--check-targets',
                     Example: '--check-targets clang llvm' will make ninja invokve 'check-clang' and 'check-llvm'.
 
                     '''),
-                    nargs='+')
-parser.add_argument('-D',
-                    '--defines',
-                    help=textwrap.dedent('''\
+    nargs='+',
+)
+parser.add_argument(
+    '-D',
+    '--defines',
+    help=textwrap.dedent('''\
                     Specify additional cmake values. These will be applied to all cmake invocations.
 
                     Example: -D LLVM_PARALLEL_COMPILE_JOBS=2 LLVM_PARALLEL_LINK_JOBS=2
@@ -157,9 +179,11 @@ parser.add_argument('-D',
                     the options to this script correspond to cmake values.
 
                     '''),
-                    nargs='+')
-parser.add_argument('--distribution-profile',
-                    help=textwrap.dedent('''\
+    nargs='+',
+)
+parser.add_argument(
+    '--distribution-profile',
+    help=textwrap.dedent('''\
                     Smartly set value of LLVM_DISTRIBUTION_COMPONENTS for final build stage. Use in
                     combination with
 
@@ -178,11 +202,13 @@ parser.add_argument('--distribution-profile',
                     The default is 'none' when '--full-toolchain' is enabled, 'kernel' if not.
 
                     '''),
-                    type=str,
-                    choices=VALID_DISTRIBUTION_PROFILES)
-parser.add_argument('-f',
-                    '--full-toolchain',
-                    help=textwrap.dedent('''\
+    type=str,
+    choices=VALID_DISTRIBUTION_PROFILES,
+)
+parser.add_argument(
+    '-f',
+    '--full-toolchain',
+    help=textwrap.dedent('''\
                     By default, the script tunes LLVM for building the Linux kernel by disabling several
                     projects, targets, and configuration options, which speeds up build times but limits
                     how the toolchain could be used.
@@ -194,18 +220,22 @@ parser.add_argument('-f',
                     system-wide toolchain.
 
                     '''),
-                    action='store_true')
-parser.add_argument('-i',
-                    '--install-folder',
-                    help=textwrap.dedent('''\
+    action='store_true',
+)
+parser.add_argument(
+    '-i',
+    '--install-folder',
+    help=textwrap.dedent('''\
                     By default, the script will leave the toolchain in its build folder. To install it
                     outside the build folder for persistent use, pass the installation location that you
                     desire to this parameter. This can be either an absolute or relative path.
 
                     '''),
-                    type=str)
-parser.add_argument('--install-targets',
-                    help=textwrap.dedent('''\
+    type=str,
+)
+parser.add_argument(
+    '--install-targets',
+    help=textwrap.dedent('''\
                     By default, the script will just run the 'install' target to install the toolchain to
                     the desired prefix. To produce a slimmer toolchain, specify the desired targets to
                     install using this options.
@@ -216,10 +246,12 @@ parser.add_argument('--install-targets',
                              'install-lld'.
 
                     '''),
-                    nargs='+')
-parser.add_argument('-l',
-                    '--llvm-folder',
-                    help=textwrap.dedent('''\
+    nargs='+',
+)
+parser.add_argument(
+    '-l',
+    '--llvm-folder',
+    help=textwrap.dedent('''\
                     By default, the script will clone the llvm-project into the tc-build repo. If you have
                     another LLVM checkout that you would like to work out of, pass it to this parameter.
                     This can either be an absolute or relative path. Implies '--no-update'. When this
@@ -227,19 +259,23 @@ parser.add_argument('-l',
                     not manipulate a repository it does not own.
 
                     '''),
-                    type=str)
-parser.add_argument('-L',
-                    '--linux-folder',
-                    help=textwrap.dedent('''\
+    type=str,
+)
+parser.add_argument(
+    '-L',
+    '--linux-folder',
+    help=textwrap.dedent('''\
                     If building with PGO, use this kernel source for building profiles instead of downloading
                     a tarball from kernel.org. This should be the full or relative path to a complete kernel
                     source directory, not a tarball or zip file.
 
                     '''),
-                    type=str)
-parser.add_argument('--lto',
-                    metavar='LTO_TYPE',
-                    help=textwrap.dedent('''\
+    type=str,
+)
+parser.add_argument(
+    '--lto',
+    metavar='LTO_TYPE',
+    help=textwrap.dedent('''\
                     Build the final compiler with either ThinLTO (thin) or full LTO (full), which can
                     often improve compile time performance by 3-5%% on average.
 
@@ -256,27 +292,33 @@ parser.add_argument('--lto',
                     https://clang.llvm.org/docs/ThinLTO.html
 
                     '''),
-                    type=str,
-                    choices=['thin', 'full'])
-parser.add_argument('-m',
-                    '--multicall',
-                    help=textwrap.dedent('''\
+    type=str,
+    choices=['thin', 'full'],
+)
+parser.add_argument(
+    '-m',
+    '--multicall',
+    help=textwrap.dedent('''\
                     Build LLVM as a multicall binary via the LLVM_TOOL_LLVM_DRIVER_BUILD CMake option.
                     This results in a much smaller installation on disk.
 
                     '''),
-                    action='store_true')
-parser.add_argument('-n',
-                    '--no-update',
-                    help=textwrap.dedent('''\
+    action='store_true',
+)
+parser.add_argument(
+    '-n',
+    '--no-update',
+    help=textwrap.dedent('''\
                     By default, the script always updates the LLVM repo before building. This prevents
                     that, which can be helpful during something like bisecting or manually managing the
                     repo to pin it to a particular revision.
 
                     '''),
-                    action='store_true')
-parser.add_argument('--no-ccache',
-                    help=textwrap.dedent('''\
+    action='store_true',
+)
+parser.add_argument(
+    '--no-ccache',
+    help=textwrap.dedent('''\
                     By default, the script adds LLVM_CCACHE_BUILD to the cmake options so that ccache is
                     used for the stage one build. This helps speed up compiles but it is only useful for
                     stage one, which is built using the host compiler, which usually does not change,
@@ -287,10 +329,12 @@ parser.add_argument('--no-ccache',
                     could be useful for benchmarking clean builds.
 
                     '''),
-                    action='store_true')
-parser.add_argument('-p',
-                    '--projects',
-                    help=textwrap.dedent('''\
+    action='store_true',
+)
+parser.add_argument(
+    '-p',
+    '--projects',
+    help=textwrap.dedent('''\
                     Currently, the script only enables the clang, compiler-rt, lld, and polly folders in LLVM.
                     If you would like to override this, you can use this parameter and supply a list that is
                     supported by LLVM_ENABLE_PROJECTS.
@@ -300,10 +344,12 @@ parser.add_argument('-p',
                     Example: -p clang lld polly
 
                     '''),
-                    nargs='+')
-opt_options.add_argument('--pgo',
-                         metavar='PGO_BENCHMARK',
-                         help=textwrap.dedent('''\
+    nargs='+',
+)
+opt_options.add_argument(
+    '--pgo',
+    metavar='PGO_BENCHMARK',
+    help=textwrap.dedent('''\
                     Build the final compiler with Profile Guided Optimization, which can often improve compile
                     time performance by 15-20%% on average. The script will:
 
@@ -347,26 +393,30 @@ opt_options.add_argument('--pgo',
                     See https://llvm.org/docs/HowToBuildWithPGO.html for more information.
 
                          '''),
-                         nargs='+',
-                         choices=[
-                             'kernel-defconfig',
-                             'kernel-allmodconfig',
-                             'kernel-allyesconfig',
-                             'kernel-defconfig-slim',
-                             'kernel-allmodconfig-slim',
-                             'kernel-allyesconfig-slim',
-                             'llvm',
-                         ])
-parser.add_argument('--quiet-cmake',
-                    help=textwrap.dedent('''\
+    nargs='+',
+    choices=[
+        'kernel-defconfig',
+        'kernel-allmodconfig',
+        'kernel-allyesconfig',
+        'kernel-defconfig-slim',
+        'kernel-allmodconfig-slim',
+        'kernel-allyesconfig-slim',
+        'llvm',
+    ],
+)
+parser.add_argument(
+    '--quiet-cmake',
+    help=textwrap.dedent('''\
                     By default, the script shows all output from cmake. When this option is enabled, the
                     invocations of cmake will only show warnings and errors.
 
                     '''),
-                    action='store_true')
-parser.add_argument('-r',
-                    '--ref',
-                    help=textwrap.dedent('''\
+    action='store_true',
+)
+parser.add_argument(
+    '-r',
+    '--ref',
+    help=textwrap.dedent('''\
                     By default, the script builds the main branch (tip of tree) of LLVM. If you would
                     like to build an older branch, use this parameter. This may be helpful in tracking
                     down an older bug to properly bisect. This value is just passed along to 'git checkout'
@@ -376,11 +426,13 @@ parser.add_argument('-r',
                     does not own.
 
                     '''),
-                    default='main',
-                    type=str)
-clone_options.add_argument('-s',
-                           '--shallow-clone',
-                           help=textwrap.dedent('''\
+    default='main',
+    type=str,
+)
+clone_options.add_argument(
+    '-s',
+    '--shallow-clone',
+    help=textwrap.dedent('''\
                     Only fetch the required objects and omit history when cloning the LLVM repo. This
                     option is only used for the initial clone, not subsequent fetches. This can break
                     the script's ability to automatically update the repo to newer revisions or branches
@@ -398,18 +450,22 @@ clone_options.add_argument('-s',
                        a branch other than main needs to be specified when the repo is first cloned.
 
                            '''),
-                           action='store_true')
-parser.add_argument('--show-build-commands',
-                    help=textwrap.dedent('''\
+    action='store_true',
+)
+parser.add_argument(
+    '--show-build-commands',
+    help=textwrap.dedent('''\
                     By default, the script only shows the output of the comands it is running. When this option
                     is enabled, the invocations of cmake, ninja, and make will be shown to help with
                     reproducing issues outside of the script.
 
                     '''),
-                    action='store_true')
-parser.add_argument('-t',
-                    '--targets',
-                    help=textwrap.dedent('''\
+    action='store_true',
+)
+parser.add_argument(
+    '-t',
+    '--targets',
+    help=textwrap.dedent('''\
                     LLVM is multitargeted by default. Currently, this script only enables the arm32, aarch64,
                     bpf, mips, powerpc, riscv, s390, and x86 backends because that's what the Linux kernel is
                     currently concerned with. If you would like to override this, you can use this parameter
@@ -420,9 +476,11 @@ parser.add_argument('-t',
                     Example: -t AArch64 ARM X86
 
                     '''),
-                    nargs='+')
-clone_options.add_argument('--use-good-revision',
-                           help=textwrap.dedent('''\
+    nargs='+',
+)
+clone_options.add_argument(
+    '--use-good-revision',
+    help=textwrap.dedent('''\
                     By default, the script updates LLVM to the latest tip of tree revision, which may at times be
                     broken or not work right. With this option, it will checkout a known good revision of LLVM
                     that builds and works properly. If you use this option often, please remember to update the
@@ -431,11 +489,13 @@ clone_options.add_argument('--use-good-revision',
                     NOTE: This option cannot be used with '--shallow-clone'.
 
                            '''),
-                           action='store_const',
-                           const=GOOD_REVISION,
-                           dest='ref')
-parser.add_argument('--vendor-string',
-                    help=textwrap.dedent('''\
+    action='store_const',
+    const=GOOD_REVISION,
+    dest='ref',
+)
+parser.add_argument(
+    '--vendor-string',
+    help=textwrap.dedent('''\
                     Add this value to the clang and ld.lld version string (like "Apple clang version..."
                     or "Android clang version..."). Useful when reverting or applying patches on top
                     of upstream clang to differentiate a toolchain built with this script from
@@ -444,8 +504,9 @@ parser.add_argument('--vendor-string',
                     override this and have no vendor in the version string.
 
                     '''),
-                    type=str,
-                    default='ClangBuiltLinux')
+    type=str,
+    default='ClangBuiltLinux',
+)
 args = parser.parse_args()
 
 # Start tracking time that the script takes
@@ -546,14 +607,17 @@ if args.bolt and not final.can_use_perf():
         )
         tc_build.utils.print_warning('https://github.com/llvm/llvm-project/issues/55004')
         tc_build.utils.print_warning(
-            "Consider adding '--assertions' if there are any failures during the BOLT stage.")
+            "Consider adding '--assertions' if there are any failures during the BOLT stage."
+        )
         warned = True
     if platform.machine() != 'x86_64':
         tc_build.utils.print_warning(
-            'Using BOLT in instrumentation mode may not work on non-x86_64 machines:')
+            'Using BOLT in instrumentation mode may not work on non-x86_64 machines:'
+        )
         tc_build.utils.print_warning('https://github.com/llvm/llvm-project/issues/55005')
         tc_build.utils.print_warning(
-            "Consider dropping '--bolt' if there are any failures during the BOLT stage.")
+            "Consider dropping '--bolt' if there are any failures during the BOLT stage."
+        )
         warned = True
     if warned:
         tc_build.utils.print_warning('Continuing in 5 seconds, hit Ctrl-C to cancel...')
@@ -573,7 +637,7 @@ if args.defines:
     common_cmake_defines.update(defines)
 
 # Build bootstrap compiler if user did not request a single stage build
-if (use_bootstrap := not args.build_stage1_only):
+if use_bootstrap := not args.build_stage1_only:
     tc_build.utils.print_header('Building LLVM (bootstrap)')
 
     bootstrap = LLVMBootstrapBuilder()
@@ -657,7 +721,8 @@ if args.pgo:
         config_target = pgo_target.split('-')[0]
         if config_target in pgo_targets:
             tc_build.utils.print_warning(
-                f"Both full and slim were specified for {config_target}, ignoring full...")
+                f"Both full and slim were specified for {config_target}, ignoring full..."
+            )
             pgo_targets.remove(config_target)
 
     if pgo_targets:
@@ -748,10 +813,7 @@ if args.bolt:
     final.bolt_builder = LLVMKernelBuilder()
     final.bolt_builder.folders.build = Path(build_folder, 'linux')
     final.bolt_builder.folders.source = lsm.location
-    if final.host_target_is_enabled():
-        llvm_targets = [final.host_target()]
-    else:
-        llvm_targets = final.targets[0:1]
+    llvm_targets = [final.host_target()] if final.host_target_is_enabled() else final.targets[0:1]
     final.bolt_builder.matrix['defconfig'] = llvm_targets
 
 tc_build.utils.print_header('Building LLVM (final)')

--- a/build-rust.py
+++ b/build-rust.py
@@ -16,17 +16,20 @@ GOOD_REVISION = '69b3959afec9b5468d5de15133b199553f6e55d2'
 parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
 clone_options = parser.add_mutually_exclusive_group()
 
-parser.add_argument('--debug',
-                    help=textwrap.dedent('''\
+parser.add_argument(
+    '--debug',
+    help=textwrap.dedent('''\
                     Build a debug compiler and standard library. This enables debug assertions,
                     debug logging, overflow checks and debug info. The debug assertions and overflow
                     checks can help catch issues when compiling.
 
                     '''),
-                    action='store_true')
-parser.add_argument('-b',
-                    '--build-folder',
-                    help=textwrap.dedent('''\
+    action='store_true',
+)
+parser.add_argument(
+    '-b',
+    '--build-folder',
+    help=textwrap.dedent('''\
                     By default, the script will create a "build/rust" folder in the same folder as this
                     script and build each requested stage within that containing folder. To change the
                     location of the containing build folder, pass it to this parameter. This can be either
@@ -34,10 +37,12 @@ parser.add_argument('-b',
                     needs to be provided as well to prevent mistakes.
 
                     '''),
-                    type=str)
-parser.add_argument('-c',
-                    '--configure-set-args',
-                    help=textwrap.dedent('''\
+    type=str,
+)
+parser.add_argument(
+    '-c',
+    '--configure-set-args',
+    help=textwrap.dedent('''\
                     Pass the provided values to configure via the '--set' argument.
 
                     For example:
@@ -51,28 +56,34 @@ parser.add_argument('-c',
                     to configure.
 
                     '''),
-                    nargs='+')
-parser.add_argument('-i',
-                    '--install-folder',
-                    help=textwrap.dedent('''\
+    nargs='+',
+)
+parser.add_argument(
+    '-i',
+    '--install-folder',
+    help=textwrap.dedent('''\
                     By default, the script will leave the toolchain in its build folder. To install it
                     outside the build folder for persistent use, pass the installation location that you
                     desire to this parameter. This can be either an absolute or relative path.
 
                     '''),
-                    type=str)
-parser.add_argument('-l',
-                    '--llvm-install-folder',
-                    help=textwrap.dedent('''\
+    type=str,
+)
+parser.add_argument(
+    '-l',
+    '--llvm-install-folder',
+    help=textwrap.dedent('''\
                     By default, the script will try to use a built LLVM by './build-llvm.py'. To use
                     another LLVM installation (perhaps from './build-llvm.py --install-folder'), pass
                     it to this parameter.
 
                     '''),
-                    type=str)
-parser.add_argument('-R',
-                    '--rust-folder',
-                    help=textwrap.dedent('''\
+    type=str,
+)
+parser.add_argument(
+    '-R',
+    '--rust-folder',
+    help=textwrap.dedent('''\
                     By default, the script will clone the Rust project into the tc-build repo. If you have
                     another Rust checkout that you would like to work out of, pass it to this parameter.
                     This can either be an absolute or relative path. Implies '--no-update'. When this
@@ -80,19 +91,23 @@ parser.add_argument('-R',
                     not manipulate a repository it does not own.
 
                     '''),
-                    type=str)
-parser.add_argument('-n',
-                    '--no-update',
-                    help=textwrap.dedent('''\
+    type=str,
+)
+parser.add_argument(
+    '-n',
+    '--no-update',
+    help=textwrap.dedent('''\
                     By default, the script always updates the Rust repo before building. This prevents
                     that, which can be helpful during something like bisecting or manually managing the
                     repo to pin it to a particular revision.
 
                     '''),
-                    action='store_true')
-parser.add_argument('-r',
-                    '--ref',
-                    help=textwrap.dedent('''\
+    action='store_true',
+)
+parser.add_argument(
+    '-r',
+    '--ref',
+    help=textwrap.dedent('''\
                     By default, the script builds the main branch (tip of tree) of Rust. If you would
                     like to build an older branch, use this parameter. This may be helpful in tracking
                     down an older bug to properly bisect. This value is just passed along to 'git checkout'
@@ -101,18 +116,22 @@ parser.add_argument('-r',
                     does not own.
 
                     '''),
-                    default='main',
-                    type=str)
-parser.add_argument('--show-build-commands',
-                    help=textwrap.dedent('''\
+    default='main',
+    type=str,
+)
+parser.add_argument(
+    '--show-build-commands',
+    help=textwrap.dedent('''\
                     By default, the script only shows the output of the comands it is running. When this option
                     is enabled, the invocations of the build tools will be shown to help with reproducing
                     issues outside of the script.
 
                     '''),
-                    action='store_true')
-clone_options.add_argument('--use-good-revision',
-                           help=textwrap.dedent('''\
+    action='store_true',
+)
+clone_options.add_argument(
+    '--use-good-revision',
+    help=textwrap.dedent('''\
                     By default, the script updates Rust to the latest tip of tree revision, which may at times be
                     broken or not work right. With this option, it will checkout a known good revision of Rust
                     that builds and works properly. If you use this option often, please remember to update the
@@ -120,11 +139,13 @@ clone_options.add_argument('--use-good-revision',
                     revision used to build LLVM by './build-llvm.py'.
 
                            '''),
-                           action='store_const',
-                           const=GOOD_REVISION,
-                           dest='ref')
-parser.add_argument('--vendor-string',
-                    help=textwrap.dedent('''\
+    action='store_const',
+    const=GOOD_REVISION,
+    dest='ref',
+)
+parser.add_argument(
+    '--vendor-string',
+    help=textwrap.dedent('''\
                     Add this value to the Rust version string (like "rustc ... (ClangBuiltLinux)"). Useful when
                     reverting or applying patches on top of upstream Rust to differentiate a toolchain built
                     with this script from upstream Rust or to distinguish a toolchain built with this script
@@ -132,8 +153,9 @@ parser.add_argument('--vendor-string',
                     override this and have no vendor in the version string.
 
                     '''),
-                    type=str,
-                    default='ClangBuiltLinux')
+    type=str,
+    default='ClangBuiltLinux',
+)
 args = parser.parse_args()
 
 # Start tracking time that the script takes

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,8 @@
 target-version = 'py39'
+line-length = 100
+
+[format]
+quote-style = 'preserve'
 
 # https://docs.astral.sh/ruff/rules/
 [lint]

--- a/tc_build/binutils.py
+++ b/tc_build/binutils.py
@@ -12,7 +12,6 @@ import tc_build.utils
 
 
 class BinutilsBuilder(Builder):
-
     def __init__(self):
         super().__init__()
 
@@ -57,8 +56,9 @@ class BinutilsBuilder(Builder):
         # .sframe generation" error by discarding .sframe altogether if
         # possible, as we may be linking against libraries with their own
         # .sframe sections and versions.
-        ld_help = subprocess.run(['ld', '--help'], capture_output=True, check=True,
-                                 text=True).stdout
+        ld_help = subprocess.run(
+            ['ld', '--help'], capture_output=True, check=True, text=True
+        ).stdout
         if '--discard-sframe' in ld_help:
             self.configure_vars['LDFLAGS'] = '-Wl,--discard-sframe'
 
@@ -87,7 +87,6 @@ class BinutilsBuilder(Builder):
 
 
 class StandardBinutilsBuilder(BinutilsBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -100,7 +99,6 @@ class StandardBinutilsBuilder(BinutilsBuilder):
 
 
 class NoMultilibBinutilsBuilder(BinutilsBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -112,7 +110,6 @@ class NoMultilibBinutilsBuilder(BinutilsBuilder):
 
 
 class ArmBinutilsBuilder(NoMultilibBinutilsBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -121,7 +118,6 @@ class ArmBinutilsBuilder(NoMultilibBinutilsBuilder):
 
 
 class AArch64BinutilsBuilder(NoMultilibBinutilsBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -130,7 +126,6 @@ class AArch64BinutilsBuilder(NoMultilibBinutilsBuilder):
 
 
 class LoongArchBinutilsBuilder(StandardBinutilsBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -139,7 +134,6 @@ class LoongArchBinutilsBuilder(StandardBinutilsBuilder):
 
 
 class MipsBinutilsBuilder(StandardBinutilsBuilder):
-
     def __init__(self, endian_suffix=''):
         super().__init__()
 
@@ -152,13 +146,11 @@ class MipsBinutilsBuilder(StandardBinutilsBuilder):
 
 
 class MipselBinutilsBuilder(MipsBinutilsBuilder):
-
     def __init__(self):
         super().__init__('el')
 
 
 class PowerPCBinutilsBuilder(StandardBinutilsBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -167,7 +159,6 @@ class PowerPCBinutilsBuilder(StandardBinutilsBuilder):
 
 
 class PowerPC64BinutilsBuilder(StandardBinutilsBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -176,7 +167,6 @@ class PowerPC64BinutilsBuilder(StandardBinutilsBuilder):
 
 
 class PowerPC64LEBinutilsBuilder(StandardBinutilsBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -185,7 +175,6 @@ class PowerPC64LEBinutilsBuilder(StandardBinutilsBuilder):
 
 
 class RISCV64BinutilsBuilder(StandardBinutilsBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -194,7 +183,6 @@ class RISCV64BinutilsBuilder(StandardBinutilsBuilder):
 
 
 class S390XBinutilsBuilder(StandardBinutilsBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -204,7 +192,6 @@ class S390XBinutilsBuilder(StandardBinutilsBuilder):
 
 
 class X8664BinutilsBuilder(StandardBinutilsBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -214,7 +201,6 @@ class X8664BinutilsBuilder(StandardBinutilsBuilder):
 
 
 class BinutilsSourceManager(SourceManager):
-
     def default_targets(self):
         targets = [
             'aarch64',

--- a/tc_build/builder.py
+++ b/tc_build/builder.py
@@ -6,7 +6,6 @@ import subprocess
 
 
 class Folders:
-
     def __init__(self):
         self.build = None
         self.install = None
@@ -14,7 +13,6 @@ class Folders:
 
 
 class Builder:
-
     def __init__(self):
         self.folders = Folders()
         self.show_commands = False
@@ -43,11 +41,9 @@ class Builder:
             # Acts sort of like 'set -x' in bash
             print(f"$ {' '.join([shlex.quote(str(elem)) for elem in cmd])}", flush=True)
         try:
-            return subprocess.run(cmd,
-                                  capture_output=capture_output,
-                                  check=True,
-                                  cwd=cwd,
-                                  text=True)
+            return subprocess.run(
+                cmd, capture_output=capture_output, check=True, cwd=cwd, text=True
+            )
         except subprocess.CalledProcessError as err:
             if capture_output:
                 if err.stdout:

--- a/tc_build/kernel.py
+++ b/tc_build/kernel.py
@@ -13,7 +13,6 @@ import tc_build.utils
 
 
 class KernelBuilder(Builder):
-
     # If the user supplies their own kernel source, it must be at least this
     # version to ensure that all the build commands work, as the build commands
     # were written to target at least this version.
@@ -83,8 +82,9 @@ class KernelBuilder(Builder):
             kconfig_allconfig = NamedTemporaryFile(dir=self.folders.build)  # noqa: SIM115
 
             configs_to_disable = ['DRM_WERROR', 'WERROR']
-            kconfig_allconfig_text = ''.join(f"CONFIG_{val}=n\n"
-                                             for val in configs_to_disable).encode('utf-8')
+            kconfig_allconfig_text = ''.join(
+                f"CONFIG_{val}=n\n" for val in configs_to_disable
+            ).encode('utf-8')
 
             kconfig_allconfig.write(kconfig_allconfig_text)
             kconfig_allconfig.seek(0)
@@ -98,7 +98,7 @@ class KernelBuilder(Builder):
                 '--event', 'cycles:u',
                 '--output', self.bolt_sampling_output,
                 '--',
-            ]  # yapf: disable
+            ]  # fmt: off
         make_cmd += ['make', '-C', self.folders.source, f"-skj{os.cpu_count()}"]
         make_cmd += [f"{key}={self.make_variables[key]}" for key in sorted(self.make_variables)]
         make_cmd += [*self.config_targets, 'all']
@@ -129,11 +129,9 @@ class KernelBuilder(Builder):
 
         clang_cmd = [clang, '-E', '-P', '-x', 'c', '-']
         clang_input = '__clang_major__ __clang_minor__ __clang_patchlevel__'
-        clang_output = subprocess.run(clang_cmd,
-                                      capture_output=True,
-                                      check=True,
-                                      input=clang_input,
-                                      text=True).stdout.strip()
+        clang_output = subprocess.run(
+            clang_cmd, capture_output=True, check=True, input=clang_input, text=True
+        ).stdout.strip()
 
         self.toolchain_version = tuple(int(elem) for elem in clang_output.split(' '))
         return self.toolchain_version
@@ -159,18 +157,15 @@ class KernelBuilder(Builder):
         prog = 'int main(void) { return 0; }'
 
         try:
-            subprocess.run([clang, *clang_args],
-                           capture_output=True,
-                           check=True,
-                           input=prog,
-                           text=True)
+            subprocess.run(
+                [clang, *clang_args], capture_output=True, check=True, input=prog, text=True
+            )
         except subprocess.CalledProcessError:
             return False
         return True
 
 
 class ArmKernelBuilder(KernelBuilder):
-
     def __init__(self):
         super().__init__('arm')
 
@@ -181,7 +176,6 @@ class ArmKernelBuilder(KernelBuilder):
 
 
 class ArmV5KernelBuilder(ArmKernelBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -189,7 +183,6 @@ class ArmV5KernelBuilder(ArmKernelBuilder):
 
 
 class ArmV6KernelBuilder(ArmKernelBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -210,7 +203,6 @@ class ArmV6KernelBuilder(ArmKernelBuilder):
 
 
 class ArmV7KernelBuilder(ArmKernelBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -218,19 +210,16 @@ class ArmV7KernelBuilder(ArmKernelBuilder):
 
 
 class Arm64KernelBuilder(KernelBuilder):
-
     def __init__(self):
         super().__init__('arm64')
 
 
 class HexagonKernelBuilder(KernelBuilder):
-
     def __init__(self):
         super().__init__('hexagon')
 
 
 class LoongArchKernelBuilder(KernelBuilder):
-
     def __init__(self):
         super().__init__('loongarch')
 
@@ -246,7 +235,6 @@ class LoongArchKernelBuilder(KernelBuilder):
 
 
 class MIPSKernelBuilder(KernelBuilder):
-
     def __init__(self):
         super().__init__('mips')
 
@@ -254,7 +242,6 @@ class MIPSKernelBuilder(KernelBuilder):
 
 
 class PowerPCKernelBuilder(KernelBuilder):
-
     def __init__(self):
         super().__init__('powerpc')
 
@@ -263,7 +250,6 @@ class PowerPCKernelBuilder(KernelBuilder):
 
 
 class PowerPC32KernelBuilder(PowerPCKernelBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -272,7 +258,6 @@ class PowerPC32KernelBuilder(PowerPCKernelBuilder):
 
 
 class PowerPC64KernelBuilder(PowerPCKernelBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -289,7 +274,6 @@ class PowerPC64KernelBuilder(PowerPCKernelBuilder):
 
 
 class PowerPC64LEKernelBuilder(PowerPC64KernelBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -305,7 +289,6 @@ class PowerPC64LEKernelBuilder(PowerPC64KernelBuilder):
 
 
 class RISCVKernelBuilder(KernelBuilder):
-
     def __init__(self):
         super().__init__('riscv')
 
@@ -317,7 +300,6 @@ class RISCVKernelBuilder(KernelBuilder):
 
 
 class S390KernelBuilder(KernelBuilder):
-
     def __init__(self):
         super().__init__('s390')
 
@@ -327,7 +309,8 @@ class S390KernelBuilder(KernelBuilder):
         if self.get_toolchain_version() <= (15, 0, 0):
             # https://git.kernel.org/linus/30d17fac6aaedb40d111bb159f4b35525637ea78
             tc_build.utils.print_warning(
-                's390 does not build with LLVM < 15.0.0, skipping build...')
+                's390 does not build with LLVM < 15.0.0, skipping build...'
+            )
             return
 
         # LD: https://github.com/ClangBuiltLinux/linux/issues/1524
@@ -335,22 +318,31 @@ class S390KernelBuilder(KernelBuilder):
         gnu_vars = []
 
         # https://github.com/llvm/llvm-project/pull/75643
-        lld_res = subprocess.run([Path(self.toolchain_prefix, 'bin/ld.lld'), '-m', 'elf64_s390'],
-                                 capture_output=True,
-                                 check=False,
-                                 text=True)
+        lld_res = subprocess.run(
+            [Path(self.toolchain_prefix, 'bin/ld.lld'), '-m', 'elf64_s390'],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
         if 'error: unknown emulation:' in lld_res.stderr:
             gnu_vars.append('LD')
 
         # https://github.com/llvm/llvm-project/pull/81841
-        objcopy_res = subprocess.run([
-            Path(self.toolchain_prefix, 'bin/llvm-objcopy'), '-I', 'binary', '-O', 'elf64-s390',
-            '-', '/dev/null'
-        ],
-                                     capture_output=True,
-                                     check=False,
-                                     input='',
-                                     text=True)
+        objcopy_res = subprocess.run(
+            [
+                Path(self.toolchain_prefix, 'bin/llvm-objcopy'),
+                '-I',
+                'binary',
+                '-O',
+                'elf64-s390',
+                '-',
+                '/dev/null',
+            ],
+            capture_output=True,
+            check=False,
+            input='',
+            text=True,
+        )
         if 'error: invalid output format:' in objcopy_res.stderr:
             gnu_vars.append('OBJCOPY')
 
@@ -367,7 +359,6 @@ class S390KernelBuilder(KernelBuilder):
 
 
 class X8664KernelBuilder(KernelBuilder):
-
     def __init__(self):
         super().__init__('x86_64')
 
@@ -378,14 +369,14 @@ class X8664KernelBuilder(KernelBuilder):
         if self.get_toolchain_version() < (15, 0, 0) and self.lsm.get_version() >= (6, 15, 0):
             # https://git.kernel.org/linus/7861640aac52bbbb3dc2cd40fb93dfb3b3d0f43c
             tc_build.utils.print_warning(
-                'x86_64 does not build with LLVM < 15.0.0 and Linux >= 6.15.0, skipping build...')
+                'x86_64 does not build with LLVM < 15.0.0 and Linux >= 6.15.0, skipping build...'
+            )
             return
 
         super().build()
 
 
 class LLVMKernelBuilder(Builder):
-
     def __init__(self):
         super().__init__()
 
@@ -467,7 +458,6 @@ class LLVMKernelBuilder(Builder):
 
 
 class LinuxSourceManager(SourceManager):
-
     def __init__(self, location=None):
         super().__init__(location)
 
@@ -475,11 +465,13 @@ class LinuxSourceManager(SourceManager):
         self._version = ()
 
     def get_kernelversion(self):
-        return subprocess.run(['make', '-s', 'kernelversion'],
-                              capture_output=True,
-                              check=True,
-                              cwd=self.location,
-                              text=True).stdout.strip()
+        return subprocess.run(
+            ['make', '-s', 'kernelversion'],
+            capture_output=True,
+            check=True,
+            cwd=self.location,
+            text=True,
+        ).stdout.strip()
 
     # Dynamically get the version of the supplied kernel source as a tuple,
     # which can be used to check if a provided kernel source is at least a
@@ -488,7 +480,8 @@ class LinuxSourceManager(SourceManager):
         # elem.split('-')[0] in case we are dealing with an -rc release.
         if not self._version:
             self._version = tuple(
-                int(elem.split('-')[0]) for elem in self.get_kernelversion().split('.', 3))
+                int(elem.split('-')[0]) for elem in self.get_kernelversion().split('.', 3)
+            )
         return self._version
 
     def prepare(self):

--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -29,19 +29,19 @@ def get_all_targets(llvm_folder, experimental=False):
             # Manually populate experimental targets based on list above
             possible_experimental_targets = ('ARC', 'CSKY', 'DirectX', 'M68k', 'SPIRV', 'Xtensa')
             targets += [
-                target for target in possible_experimental_targets
+                target
+                for target in possible_experimental_targets
                 if Path(llvm_folder, 'llvm/lib/Target', target).exists()
             ]
 
     for variable in variables:
-        if not (match := re.search(fr"set\({variable}([\w|\s]+)\)", contents)):
+        if not (match := re.search(rf"set\({variable}([\w|\s]+)\)", contents)):
             raise RuntimeError(f"Could not find {variables}?")
         targets += [val for target in match.group(1).splitlines() if (val := target.strip())]
     return targets
 
 
 class LLVMBuilder(Builder):
-
     def __init__(self):
         super().__init__()
 
@@ -141,13 +141,17 @@ class LLVMBuilder(Builder):
             # inspected.
             merge_fdata_log = Path(self.folders.build, 'merge-fdata.log')
 
-            with bolt_profile.open('w', encoding='utf-8') as out_file, \
-                 merge_fdata_log.open('w', encoding='utf-8') as err_file:
+            with (
+                bolt_profile.open('w', encoding='utf-8') as out_file,
+                merge_fdata_log.open('w', encoding='utf-8') as err_file,
+            ):
                 tc_build.utils.print_info('Merging .fdata files, this might take a while...')
-                subprocess.run([self.tools.merge_fdata, *list(fdata_files)],
-                               check=True,
-                               stderr=err_file,
-                               stdout=out_file)
+                subprocess.run(
+                    [self.tools.merge_fdata, *list(fdata_files)],
+                    check=True,
+                    stderr=err_file,
+                    stdout=out_file,
+                )
             for fdata_file in fdata_files:
                 fdata_file.unlink()
 
@@ -167,8 +171,9 @@ class LLVMBuilder(Builder):
         bolt_readme = Path(self.folders.source, 'bolt/README.md').read_text(encoding='utf-8')
         use_cache_plus = '-reorder-blocks=cache+' in bolt_readme
         use_sf_val = '-split-functions=2' in bolt_readme
-        if (bolt_cmd_ref := Path(self.folders.source,
-                                 'bolt/docs/CommandLineArgumentReference.md')).exists():
+        if (
+            bolt_cmd_ref := Path(self.folders.source, 'bolt/docs/CommandLineArgumentReference.md')
+        ).exists():
             bolt_cmd_ref_txt = bolt_cmd_ref.read_text(encoding='utf-8')
             # https://github.com/llvm/llvm-project/commit/3c357a49d61e4c81a1ac016502ee504521bc8dda
             icf_val = 'all' if '--icf=<value>' in bolt_cmd_ref_txt else '1'
@@ -237,7 +242,7 @@ class LLVMBuilder(Builder):
                     '--event', 'cycles:u',
                     '--output', '/dev/null',
                     '--', 'sleep', '1',
-                ]  # yapf: disable
+                ]  # fmt: off
                 subprocess.run(perf_cmd, capture_output=True, check=True)
             except subprocess.CalledProcessError:
                 pass  # Fallthrough to False below
@@ -267,7 +272,7 @@ class LLVMBuilder(Builder):
         self.validate_targets()
         self.set_llvm_major_version()
 
-        # yapf: disable
+        # fmt: off
         cmake_cmd = [
             'cmake',
             '-B', self.folders.build,
@@ -275,7 +280,7 @@ class LLVMBuilder(Builder):
             '-S', Path(self.folders.source, 'llvm'),
             '-Wno-dev',
         ]
-        # yapf: enable
+        # fmt: on
         if self.quiet_cmake:
             cmake_cmd.append('--log-level=NOTICE')
 
@@ -285,7 +290,8 @@ class LLVMBuilder(Builder):
                 self.cmake_defines['CMAKE_CXX_COMPILER_LAUNCHER'] = 'ccache'
             else:
                 tc_build.utils.print_warning(
-                    'ccache requested but could not be found on your system, ignoring...')
+                    'ccache requested but could not be found on your system, ignoring...'
+                )
 
         if self.tools.clang_tblgen:
             self.cmake_defines['CLANG_TABLEGEN'] = self.tools.clang_tblgen
@@ -306,7 +312,8 @@ class LLVMBuilder(Builder):
         # https://github.com/llvm/llvm-project/commit/b593110d89aea76b8b10152b24ece154bff3e4b5
         llvm_enable_projects = self.projects.copy()
         if self.llvm_major_version >= LLVM_VER_FOR_RUNTIMES and self.project_is_enabled(
-                'compiler-rt'):
+            'compiler-rt'
+        ):
             llvm_enable_projects.remove('compiler-rt')
             self.cmake_defines['LLVM_ENABLE_RUNTIMES'] = 'compiler-rt'
         self.cmake_defines['LLVM_ENABLE_PROJECTS'] = ';'.join(llvm_enable_projects)
@@ -350,7 +357,8 @@ class LLVMBuilder(Builder):
             self.cmake_defines['LLVM_TARGETS_TO_BUILD'] = ';'.join(standard_targets)
         if experimental_targets:
             self.cmake_defines['LLVM_EXPERIMENTAL_TARGETS_TO_BUILD'] = ';'.join(
-                experimental_targets)
+                experimental_targets
+            )
 
         # Clear Linux needs a different target to find all of the C++ header files, otherwise
         # stage 2+ compiles will fail without this
@@ -366,10 +374,9 @@ class LLVMBuilder(Builder):
         # toolchain, as this may not be portable. Since distribution is not a
         # primary goal of tc-build, this is not abstracted further.
         if shutil.which('clang') and not os.environ.get('DISTRIBUTING'):
-            default_target_triple = subprocess.run(['clang', '-print-target-triple'],
-                                                   capture_output=True,
-                                                   check=True,
-                                                   text=True).stdout.strip()
+            default_target_triple = subprocess.run(
+                ['clang', '-print-target-triple'], capture_output=True, check=True, text=True
+            ).stdout.strip()
             self.cmake_defines['LLVM_DEFAULT_TARGET_TRIPLE'] = default_target_triple
 
         self.handle_distribution_profile()
@@ -440,7 +447,8 @@ class LLVMBuilder(Builder):
             # binary.
             if self.multicall_is_enabled():
                 distribution_components += [
-                    item for item in self.llvm_driver_binaries('llvm')
+                    item
+                    for item in self.llvm_driver_binaries('llvm')
                     if item not in distribution_components
                 ]
         if self.project_is_enabled('bolt'):
@@ -449,7 +457,8 @@ class LLVMBuilder(Builder):
             distribution_components += ['clang', 'clang-resource-headers']
             if self.multicall_is_enabled():
                 distribution_components += [
-                    item for item in self.llvm_driver_binaries('clang')
+                    item
+                    for item in self.llvm_driver_binaries('clang')
                     if item not in distribution_components
                 ]
         if self.project_is_enabled('lld'):
@@ -472,7 +481,8 @@ class LLVMBuilder(Builder):
             self.cmake_defines['LLVM_DISTRIBUTION_COMPONENTS'] = ';'.join(distribution_components)
         if runtime_distribution_components:
             self.cmake_defines['LLVM_RUNTIME_DISTRIBUTION_COMPONENTS'] = ';'.join(
-                runtime_distribution_components)
+                runtime_distribution_components
+            )
 
     def host_target(self):
         uname_to_llvm = {
@@ -503,10 +513,12 @@ class LLVMBuilder(Builder):
         ]
         skip_tools = (
             # llvm-mt depends on libxml2, which we explicitly do not link against
-            'llvm-mt', )
+            'llvm-mt',
+        )
         # Return the values of the add_clang_tool() or add_llvm_tool() CMake macros
         return [
-            tool for cmakelists_txt in cmakelists_txts
+            tool
+            for cmakelists_txt in cmakelists_txts
             if (match := re.search(r"^add_(?:clang|llvm)_tool\((.*)$", cmakelists_txt, flags=re.M))
             and (tool := match.groups()[0]) not in skip_tools
         ]
@@ -522,12 +534,14 @@ class LLVMBuilder(Builder):
             return  # no need to set if already set
         if not self.folders.source:
             raise RuntimeError('No source folder set?')
-        if (llvmversion_cmake := Path(self.folders.source,
-                                      'cmake/Modules/LLVMVersion.cmake')).exists():
+        if (
+            llvmversion_cmake := Path(self.folders.source, 'cmake/Modules/LLVMVersion.cmake')
+        ).exists():
             text_to_search = llvmversion_cmake.read_text(encoding='utf-8')
         else:
-            text_to_search = Path(self.folders.source,
-                                  'llvm/CMakeLists.txt').read_text(encoding='utf-8')
+            text_to_search = Path(self.folders.source, 'llvm/CMakeLists.txt').read_text(
+                encoding='utf-8'
+            )
         if not (match := re.search(r'set\(LLVM_VERSION_MAJOR (\d+)\)', text_to_search)):
             raise RuntimeError('Could not find LLVM_VERSION_MAJOR in text?')
         self.llvm_major_version = int(match.group(1))
@@ -544,12 +558,14 @@ class LLVMBuilder(Builder):
             raise RuntimeError('bin folder does not exist in installation folder, run build()?')
 
         tc_build.utils.print_header('LLVM installation information')
-        install_info = (f"Toolchain is available at: {install_folder}\n\n"
-                        'To use, either run:\n\n'
-                        f"\t$ export PATH={bin_folder}:$PATH\n\n"
-                        'or add:\n\n'
-                        f"\tPATH={bin_folder}:$PATH\n\n"
-                        'before the command you want to use this toolchain.\n')
+        install_info = (
+            f"Toolchain is available at: {install_folder}\n\n"
+            'To use, either run:\n\n'
+            f"\t$ export PATH={bin_folder}:$PATH\n\n"
+            'or add:\n\n'
+            f"\tPATH={bin_folder}:$PATH\n\n"
+            'before the command you want to use this toolchain.\n'
+        )
         print(install_info)
 
         for tool in ['clang', 'ld.lld']:
@@ -579,14 +595,13 @@ class LLVMBuilder(Builder):
 
 
 class LLVMSlimBuilder(LLVMBuilder):
-
     def __init__(self):
         super().__init__()
 
         self.distribution_profile = 'kernel'
 
     def configure(self):
-        # yapf: disable
+        # fmt: off
         slim_clang_defines = {
             # We don't (currently) use the static analyzer and it saves cycles
             # according to Chromium OS:
@@ -628,7 +643,7 @@ class LLVMSlimBuilder(LLVMBuilder):
             'COMPILER_RT_BUILD_CRT': 'OFF',
             'COMPILER_RT_BUILD_XRAY': 'OFF',
         }
-        # yapf: enable
+        # fmt: on
 
         self.cmake_defines.update(slim_llvm_defines)
         if self.project_is_enabled('clang'):
@@ -644,7 +659,6 @@ class LLVMSlimBuilder(LLVMBuilder):
 
 
 class LLVMBootstrapBuilder(LLVMSlimBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -666,7 +680,6 @@ class LLVMBootstrapBuilder(LLVMSlimBuilder):
 
 
 class LLVMInstrumentedBuilder(LLVMBuilder):
-
     def __init__(self):
         super().__init__()
 
@@ -734,7 +747,6 @@ class LLVMSlimInstrumentedBuilder(LLVMInstrumentedBuilder, LLVMSlimBuilder):
 
 
 class LLVMSourceManager(GitSourceManager):
-
     def __init__(self, repo):
         super().__init__(repo)
 
@@ -747,8 +759,16 @@ class LLVMSourceManager(GitSourceManager):
     def default_targets(self):
         all_targets = get_all_targets(self.repo)
         targets = [
-            'AArch64', 'ARM', 'BPF', 'Hexagon', 'Mips', 'PowerPC', 'RISCV', 'Sparc', 'SystemZ',
-            'X86'
+            'AArch64',
+            'ARM',
+            'BPF',
+            'Hexagon',
+            'Mips',
+            'PowerPC',
+            'RISCV',
+            'Sparc',
+            'SystemZ',
+            'X86',
         ]
 
         if 'LoongArch' in all_targets:

--- a/tc_build/rust.py
+++ b/tc_build/rust.py
@@ -10,7 +10,6 @@ import tc_build.utils
 
 
 class RustBuilder(Builder):
-
     def __init__(self):
         super().__init__()
 
@@ -46,7 +45,7 @@ class RustBuilder(Builder):
         # 'codegen-tests' requires '-DLLVM_INSTALL_UTILS=ON'.
         install_folder = self.folders.install if self.folders.install else self.folders.build
 
-        # yapf: disable
+        # fmt: off
         configure_cmd = [
             Path(self.folders.source, 'configure'),
             '--release-description', self.vendor_string,
@@ -61,7 +60,7 @@ class RustBuilder(Builder):
             '--disable-llvm-bitcode-linker',
             '--llvm-root', self.llvm_install_folder,
         ]
-        # yapf: enable
+        # fmt: on
 
         if self.debug:
             configure_cmd.append('--enable-debug')
@@ -85,12 +84,14 @@ class RustBuilder(Builder):
             raise RuntimeError('bin folder does not exist in installation folder, run build()?')
 
         tc_build.utils.print_header('Rust installation information')
-        install_info = (f"Toolchain is available at: {install_folder}\n\n"
-                        'To use, either run:\n\n'
-                        f"\t$ export PATH={bin_folder}:$PATH\n\n"
-                        'or add:\n\n'
-                        f"\tPATH={bin_folder}:$PATH\n\n"
-                        'before the command you want to use this toolchain.\n')
+        install_info = (
+            f"Toolchain is available at: {install_folder}\n\n"
+            'To use, either run:\n\n'
+            f"\t$ export PATH={bin_folder}:$PATH\n\n"
+            'or add:\n\n'
+            f"\tPATH={bin_folder}:$PATH\n\n"
+            'before the command you want to use this toolchain.\n'
+        )
         print(install_info)
 
         for tool in ['rustc', 'rustdoc', 'rustfmt', 'clippy-driver', 'cargo']:
@@ -101,7 +102,6 @@ class RustBuilder(Builder):
 
 
 class RustSourceManager(GitSourceManager):
-
     def __init__(self, repo):
         super().__init__(repo)
 

--- a/tc_build/source.py
+++ b/tc_build/source.py
@@ -13,7 +13,6 @@ BYTES_TO_READ = 131072
 
 
 class Tarball:
-
     def __init__(self):
         self.base_download_url = None
         self.local_location = None
@@ -40,8 +39,11 @@ class Tarball:
         # and finally compare the two.
         if self.remote_checksum_name:
             checksums = tc_build.utils.curl(f"{self.base_download_url}/{self.remote_checksum_name}")
-            if not (match := re.search(
-                    fr"([0-9a-f]+)\s+{self.remote_tarball_name}$", checksums, flags=re.M)):
+            if not (
+                match := re.search(
+                    rf"([0-9a-f]+)\s+{self.remote_tarball_name}$", checksums, flags=re.M
+                )
+            ):
                 raise RuntimeError(f"Could not find checksum for {self.remote_tarball_name}?")
 
             if 'sha256' in self.remote_checksum_name:
@@ -50,9 +52,10 @@ class Tarball:
                 file_hash = hashlib.sha512()
             else:
                 raise RuntimeError(
-                    f"No supported hashlib for {self.remote_checksum_name}, add support for it?")
+                    f"No supported hashlib for {self.remote_checksum_name}, add support for it?"
+                )
             with self.local_location.open('rb') as file:
-                while (data := file.read(BYTES_TO_READ)):
+                while data := file.read(BYTES_TO_READ):
                     file_hash.update(data)
 
             computed_checksum = file_hash.hexdigest()
@@ -67,7 +70,8 @@ class Tarball:
             raise RuntimeError('No local tarball location specified?')
         if not self.local_location.exists():
             raise RuntimeError(
-                f"Local tarball ('{self.local_location}') could not be found, download it first?")
+                f"Local tarball ('{self.local_location}') could not be found, download it first?"
+            )
 
         extraction_location.mkdir(exist_ok=True, parents=True)
         tar_cmd = [
@@ -84,14 +88,12 @@ class Tarball:
 
 
 class SourceManager:
-
     def __init__(self, location=None):
         self.location = location
         self.tarball = Tarball()
 
 
 class GitSourceManager:
-
     def __init__(self, repo):
         self.repo = repo
 
@@ -117,11 +119,9 @@ class GitSourceManager:
         self.git(['checkout', ref])
 
     def git(self, cmd, capture_output=False):
-        return subprocess.run(['git', *cmd],
-                              capture_output=capture_output,
-                              check=True,
-                              cwd=self.repo,
-                              text=True)
+        return subprocess.run(
+            ['git', *cmd], capture_output=capture_output, check=True, cwd=self.repo, text=True
+        )
 
     def git_capture(self, cmd):
         return self.git(cmd, capture_output=True).stdout.strip()

--- a/tc_build/tools.py
+++ b/tc_build/tools.py
@@ -11,7 +11,6 @@ import tc_build.utils
 
 
 class HostTools:
-
     def __init__(self):
         self.cc = self.find_host_cc()
         self.cc_is_clang = 'clang' in self.cc.name
@@ -46,7 +45,7 @@ class HostTools:
         # versioned LLVM binaries on Debian and Ubuntu. We do not want to
         # resolve a multicall binary though, as the symlink is how it works
         # properly.
-        if (cc := self.from_env('CC')):
+        if cc := self.from_env('CC'):
             return cc if self.cc_is_multicall(cc) else cc.resolve()
 
         # As a special case, see if the first clang command in PATH is a
@@ -60,7 +59,7 @@ class HostTools:
 
         possible_c_compilers = [*self.generate_versioned_binaries(), 'clang', 'gcc']
         for compiler in possible_c_compilers:
-            if (cc := shutil.which(compiler)):
+            if cc := shutil.which(compiler):
                 break
         else:
             raise RuntimeError('Neither clang nor gcc could be found on your system?')
@@ -68,7 +67,7 @@ class HostTools:
         return Path(cc).resolve()  # resolve() for Debian/Ubuntu variants
 
     def find_host_cxx(self):
-        if (cxx := self.from_env('CXX')):
+        if cxx := self.from_env('CXX'):
             return cxx
 
         possible_cxx_compiler = 'clang++' if self.cc_is_clang else 'g++'
@@ -79,12 +78,13 @@ class HostTools:
 
         if not (cxx := shutil.which(possible_cxx_compiler)):
             raise RuntimeError(
-                f"CXX ('{possible_cxx_compiler}') could not be found on your system?")
+                f"CXX ('{possible_cxx_compiler}') could not be found on your system?"
+            )
 
         return Path(cxx)
 
     def find_host_ld(self):
-        if (ld := self.from_env('LD')):
+        if ld := self.from_env('LD'):
             return ld
 
         if self.cc_is_clang:
@@ -96,7 +96,7 @@ class HostTools:
             # If not, try to find a suitable linker via PATH
             possible_linkers = ['lld', 'gold', 'bfd']
             for linker in possible_linkers:
-                if (ld := shutil.which(f"ld.{linker}")):
+                if ld := shutil.which(f"ld.{linker}"):
                     break
             if not ld:
                 return None
@@ -124,7 +124,8 @@ class HostTools:
 
         if not (tool := shutil.which(os.environ[key])):
             raise RuntimeError(
-                f"{key} value ('{os.environ[key]}') could not be found on your system?")
+                f"{key} value ('{os.environ[key]}') could not be found on your system?"
+            )
         return Path(tool)
 
     def generate_versioned_binaries(self):
@@ -158,22 +159,24 @@ class HostTools:
 
         cc_cmd = [self.cc, f'-fuse-ld={ld}', '-o', '/dev/null', '-x', 'c', '-']
         try:
-            subprocess.run(cc_cmd,
-                           capture_output=True,
-                           check=True,
-                           input='int main(void) { return 0; }',
-                           text=True)
+            subprocess.run(
+                cc_cmd,
+                capture_output=True,
+                check=True,
+                input='int main(void) { return 0; }',
+                text=True,
+            )
         except subprocess.CalledProcessError:
             if warn:
                 tc_build.utils.print_warning(
-                    f"LD value ('{ld}') is not supported by CC ('{self.cc}'), ignoring it...")
+                    f"LD value ('{ld}') is not supported by CC ('{self.cc}'), ignoring it..."
+                )
             return None
 
         return ld
 
 
 class StageTools:
-
     def __init__(self, bin_folder):
         # Used by cmake
         self.ar = Path(bin_folder, 'llvm-ar')


### PR DESCRIPTION
We started using `ruff` for linting a while ago. Since then, it has grown a formatting option, which is quite fast. While it is a little less flexible than `yapf`, we don't customize it much other than style and line length, the latter of which `ruff` also allows us to customize.

Switch to `ruff` for formatting. Most of the changes end up making the code a little more readable, at the expense of some extra lines. Switch to the generic `fmt` comments instead of the `yapf` specific ones. Use the option to preserve our quoting style, which uses single quotes for string literals and double quotes for f-string or raw strings.

NOTE: The linting job will not succeed until https://github.com/ClangBuiltLinux/actions-workflows/pull/11 is merged.
