### PR TITLE
Bump PGO kernel to 7.0 and bump known good revision

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -34,7 +34,7 @@ except ImportError:
     BOOL_ARGS = {'action': 'store_true'}
 
 # This is a known good revision of LLVM for building the kernel
-GOOD_REVISION = '2a2a394215b38631588d504d2b671df13370395b'
+GOOD_REVISION = 'a2c6b34193fbcaf76d48d2896c816adb9ee45ffe'
 
 # The version of the Linux kernel that the script downloads if necessary
 DEFAULT_KERNEL_FOR_PGO = (7, 0, 0)

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -37,7 +37,7 @@ except ImportError:
 GOOD_REVISION = '2a2a394215b38631588d504d2b671df13370395b'
 
 # The version of the Linux kernel that the script downloads if necessary
-DEFAULT_KERNEL_FOR_PGO = (6, 19, 0)
+DEFAULT_KERNEL_FOR_PGO = (7, 0, 0)
 
 parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
 clone_options = parser.add_mutually_exclusive_group()

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -549,12 +549,14 @@ if args.bolt or (args.pgo and [x for x in args.pgo if 'kernel' in x]):
                 f"Supplied kernel source version ('{found_version}') is older than the minimum required version ('{minimum_version}'), provide a newer version!"
             )
     else:
-        # Turns (6, 2, 0) into 6.2 and (6, 2, 1) into 6.2.1 to follow tarball names
-        ver_str = '.'.join(str(x) for x in DEFAULT_KERNEL_FOR_PGO if x)
-        lsm.location = Path(src_folder, f"linux-{ver_str}")
+        # Turns (x, y, 0) into x.y and (x, y, 1) into x.y.1 to follow tarball names
+        ver_parts = [str(x) for x in DEFAULT_KERNEL_FOR_PGO if x]
+        if len(ver_parts) == 1:  # turn (x, ) into (x, 0) for x.0 release
+            ver_parts.append('0')
+        lsm.location = Path(src_folder, f"linux-{'.'.join(ver_parts)}")
         lsm.patches = list(src_folder.glob('*.patch'))
 
-        lsm.tarball.base_download_url = 'https://cdn.kernel.org/pub/linux/kernel/v6.x'
+        lsm.tarball.base_download_url = f"https://cdn.kernel.org/pub/linux/kernel/v{ver_parts[0]}.x"
         lsm.tarball.local_location = lsm.location.with_name(f"{lsm.location.name}.tar.xz")
         lsm.tarball.remote_checksum_name = 'sha256sums.asc'
 


### PR DESCRIPTION
This includes a fix to the default PGO kernel download logic (see the first change for those details). This has been lightly qualified on an aarch64 and x86_64 host with the environment and configuration that I build the kernel.org toolchains with.
