### PR TITLE
tc_build: tools: Update variable names and assertion message in generate_versioned_binaries()

### DIFF
--- a/tc_build/tools.py
+++ b/tc_build/tools.py
@@ -17,14 +17,15 @@ def cc_is_multicall(cc: Path | str) -> bool:
 
 def generate_versioned_binaries() -> list[str]:
     try:
-        cmakelists_txt = tc_build.utils.curl(
-            'https://raw.githubusercontent.com/llvm/llvm-project/main/cmake/Modules/LLVMVersion.cmake'
+        llvmversion_cmake = 'cmake/Modules/LLVMVersion.cmake'
+        llvmversion_cmake_txt = tc_build.utils.curl(
+            f"https://raw.githubusercontent.com/llvm/llvm-project/main/{llvmversion_cmake}"
         )
     except subprocess.CalledProcessError:
         llvm_tot_ver = 23
     else:
-        if not (match := re.search(r'set\(LLVM_VERSION_MAJOR\s+(\d+)', cmakelists_txt)):
-            msg = 'Could not find LLVM_VERSION_MAJOR in CMakeLists.txt?'
+        if not (match := re.search(r'set\(LLVM_VERSION_MAJOR\s+(\d+)', llvmversion_cmake_txt)):
+            msg = f"Could not find LLVM_VERSION_MAJOR in {llvmversion_cmake}"
             raise RuntimeError(msg)
         llvm_tot_ver = int(match.groups()[0])
 


### PR DESCRIPTION
As pointed out by Harsh in #330, we are no longer downloading CMakeLists.txt for LLVM's main version, as it was moved to cmake/Modules/LLVMVersion.cmake. Update the variable names and the file name reported to the user to be fully accurate.
