### PR TITLE
src: Add two patches for -Wunused-but-set-global

### DIFF
--- a/src/20260325_nathan_extract_cert_wrap_key_pass_with_ifdef_use_pkcs11_engine.patch
+++ b/src/20260325_nathan_extract_cert_wrap_key_pass_with_ifdef_use_pkcs11_engine.patch
@@ -1,0 +1,76 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH] extract-cert: Wrap key_pass with '#ifdef
+ USE_PKCS11_ENGINE'
+From: Nathan Chancellor <nathan@kernel.org>
+Date: Wed, 25 Mar 2026 18:19:15 -0700
+Message-Id: <20260325-certs-extract-cert-key_pass-unused-but-set-global-v1-1-ecf94326d532@kernel.org>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+A recent strengthening of -Wunused-but-set-variable (enabled with -Wall)
+in clang under a new subwarning, -Wunused-but-set-global, points out an
+unused static global variable in certs/extract-cert.c:
+
+  certs/extract-cert.c:46:20: error: variable 'key_pass' set but not used [-Werror,-Wunused-but-set-global]
+     46 | static const char *key_pass;
+        |                    ^
+
+After commit 558bdc45dfb2 ("sign-file,extract-cert: use pkcs11 provider
+for OPENSSL MAJOR >= 3"), key_pass is only used with the OpenSSL engine
+API, not the new provider API. Wrap key_pass's declaration and
+assignment with '#ifdef USE_PKCS11_ENGINE' so that it is only included
+with its use to clear up the warning. While this is a little uglier than
+just marking key_pass with the unused attribute, this will make it
+easier to clean up all code associated with the use of the engine API if
+it were ever removed in the future. While in the area, use a tab for
+the key_pass assignment line to match the rest of the file.
+
+Cc: stable@vger.kernel.org
+Fixes: 558bdc45dfb2 ("sign-file,extract-cert: use pkcs11 provider for OPENSSL MAJOR >= 3")
+Reviewed-by: Nick Desaulniers <ndesaulniers@google.com>
+Tested-by: Nick Desaulniers <ndesaulniers@google.com>
+Link: https://patch.msgid.link/20260325-certs-extract-cert-key_pass-unused-but-set-global-v1-1-ecf94326d532@kernel.org
+Signed-off-by: Nathan Chancellor <nathan@kernel.org>
+---
+I am taking a fix for a similar warning in modpost through the kbuild
+tree so I don't mind picking this up with an appropriate Ack or it can
+just go through the keyring tree, does not matter to me.
+---
+ certs/extract-cert.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/certs/extract-cert.c b/certs/extract-cert.c
+index 7d6d468ed612..54ecd1024274 100644
+--- a/certs/extract-cert.c
++++ b/certs/extract-cert.c
+@@ -43,7 +43,9 @@ void format(void)
+ 	exit(2);
+ }
+ 
++#ifdef USE_PKCS11_ENGINE
+ static const char *key_pass;
++#endif
+ static BIO *wb;
+ static char *cert_dst;
+ static bool verbose;
+@@ -135,7 +137,9 @@ int main(int argc, char **argv)
+ 	if (verbose_env && strchr(verbose_env, '1'))
+ 		verbose = true;
+ 
+-        key_pass = getenv("KBUILD_SIGN_PIN");
++#ifdef USE_PKCS11_ENGINE
++	key_pass = getenv("KBUILD_SIGN_PIN");
++#endif
+ 
+ 	if (argc != 3)
+ 		format();
+
+---
+base-commit: d2a43e7f89da55d6f0f96aaadaa243f35557291e
+change-id: 20260325-certs-extract-cert-key_pass-unused-but-set-global-23007ecfadf9
+
+Best regards,
+--  
+Nathan Chancellor <nathan@kernel.org>
+

--- a/src/20260327_nathan_scripts_dtc_remove_unused_dts_version_in_dtc_lexer_l.patch
+++ b/src/20260327_nathan_scripts_dtc_remove_unused_dts_version_in_dtc_lexer_l.patch
@@ -1,0 +1,63 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH] scripts/dtc: Remove unused dts_version in dtc-lexer.l
+From: Nathan Chancellor <nathan@kernel.org>
+Date: Fri, 27 Mar 2026 22:38:55 +0100
+Message-Id: <20260327-dtc-drop-dts_version-v1-1-41066690aefd@kernel.org>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+A recent strengthening of -Wunused-but-set-variable (enabled with -Wall)
+in clang under a new subwarning, -Wunused-but-set-global, points out an
+unused static global variable in dtc-lexer.lex.c (compiled from
+dtc-lexer.l):
+
+  scripts/dtc/dtc-lexer.lex.c:641:12: warning: variable 'dts_version' set but not used [-Wunused-but-set-global]
+    641 | static int dts_version = 1;
+        |            ^
+
+This variable has been unused since commit 658f29a51e98 ("of/flattree:
+Update dtc to current mainline."). Remove it to clear up the warning.
+
+Cc: stable@vger.kernel.org
+Link: https://patch.msgid.link/20260327-dtc-drop-dts_version-v1-1-41066690aefd@kernel.org
+Signed-off-by: Nathan Chancellor <nathan@kernel.org>
+---
+This is commit 53373d1 ("dtc: Remove unused dts_version in dtc-lexer.l")
+in upstream dtc. I sent it separately to make it easier to backport to
+stable, along with updating the warning and hash to match the kernel's
+version.
+---
+ scripts/dtc/dtc-lexer.l | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index 15d585c80798..1b129b118b0f 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -39,8 +39,6 @@ extern bool treesource_error;
+ #define DPRINT(fmt, ...)	do { } while (0)
+ #endif
+ 
+-static int dts_version = 1;
+-
+ #define BEGIN_DEFAULT()		DPRINT("<V1>\n"); \
+ 				BEGIN(V1); \
+ 
+@@ -101,7 +99,6 @@ static void PRINTF(1, 2) lexical_error(const char *fmt, ...);
+ 
+ <*>"/dts-v1/"	{
+ 			DPRINT("Keyword: /dts-v1/\n");
+-			dts_version = 1;
+ 			BEGIN_DEFAULT();
+ 			return DT_V1;
+ 		}
+
+---
+base-commit: c369299895a591d96745d6492d4888259b004a9e
+change-id: 20260327-dtc-drop-dts_version-153e81c6641c
+
+Best regards,
+--  
+Nathan Chancellor <nathan@kernel.org>
+


### PR DESCRIPTION
Tip of tree LLVM has a new subwarning under `-Wunused-but-set-variable`, `-Wunused-but-set-global`, that triggers in a couple of places in the host tools. Since commit [7ded7d37e5f5](https://git.kernel.org/linus/7ded7d37e5f5b36b4acd74380156cf07b6640c5b) ("scripts/Makefile.extrawarn: Respect CONFIG_WERROR / W=e for hostprogs") in 6.18, `-Werror` has been enabled in `HOSTCFLAGS` with `CONFIG_WERROR`, which may be enabled by defconfigs. Add the two known fixes needed for a clean build. They should both be merged in 7.1 then they can be backported to the stable trees.
