### PR TITLE
build-llvm.py: Fix DEFAULT_KERNEL_FOR_PGO version parsing

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -548,9 +548,9 @@ if args.bolt or (args.pgo and [x for x in args.pgo if 'kernel' in x]):
             raise RuntimeError(msg)
     else:
         # Turns (x, y, 0) into x.y and (x, y, 1) into x.y.1 to follow tarball names
-        ver_parts = [str(x) for x in DEFAULT_KERNEL_FOR_PGO if x]
-        if len(ver_parts) == 1:  # turn (x, ) into (x, 0) for x.0 release
-            ver_parts.append('0')
+        ver_parts = [str(x) for x in DEFAULT_KERNEL_FOR_PGO]
+        if ver_parts[1] == '0' and ver_parts[2] == '0':
+            ver_parts.remove('0')
         lsm.location = Path(src_folder, f"linux-{'.'.join(ver_parts)}")
         lsm.patches = list(src_folder.glob('*.patch'))
 


### PR DESCRIPTION
Commit https://github.com/ClangBuiltLinux/tc-build/commit/5c7a3ca2f92cc149b0bb9778d2170b02f1c1106d fixed the problem with parsing a "x.0.0" kernel version, but it introduced a new problem with versions "x.0.y":

Due to the `for x in DEFAULT_KERNEL_FOR_PGO if x` condition, the zeros are dropped, which in case of e.g. `(7, 0, 0)` results in "7", and a zero is added back again through `append` to give the correct `linux-7.0.tar.xz`.

However, this does not work if there is only one zero: `(7, 0, 5)` will be turned into `7, 5`, and since it has more than one element, no zero gets added thus giving a wrong file location of `linux-7.5.tar.xz`.

Fix this by removing the "if x" condition, checking only for the special case of "x.0.0" where one zero is removed to give the correct location.