### PR TITLE
build-llvm.py: Hide ty "invalid-argument-type" warning

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -638,7 +638,7 @@ if args.multicall:
     common_cmake_defines['LLVM_TOOL_LLVM_DRIVER_BUILD'] = 'ON'
 if args.defines:
     defines = dict(define.split('=', 1) for define in args.defines)
-    common_cmake_defines.update(defines)
+    common_cmake_defines.update(defines)  # ty: ignore[invalid-argument-type]
 
 # Build bootstrap compiler if user did not request a single stage build
 if use_bootstrap := not args.build_stage1_only:


### PR DESCRIPTION
As of `ty 0.0.49`, there is a warning when updating a `TypedDict` variable with a regular dictionary:

```
error[invalid-argument-type]: Argument is incorrect
   --> build-llvm.py:641:33
    |
641 |     common_cmake_defines.update(defines)
    |                                 ^^^^^^^ Expected `<TypedDict with items '...'>`, found `dict[Unknown, Unknown]`
    |

Found 1 diagnostic
```

This is expected, as the user is allowed provide whatever `cmake` defines they would want. Suppress the warning, as there is nothing for us to do.
