### PR TITLE
build-binutils.py: 2.46.1

### DIFF
--- a/build-binutils.py
+++ b/build-binutils.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import tc_build.binutils
 import tc_build.utils
 
-LATEST_BINUTILS_RELEASE = (2, 46, 0)
+LATEST_BINUTILS_RELEASE = (2, 46, 1)
 
 parser = ArgumentParser()
 parser.add_argument(
@@ -91,10 +91,7 @@ if args.binutils_folder:
         raise RuntimeError(msg)
 else:
     # Turns (2, 40, 0) into 2.40 and (2, 40, 1) into 2.40.1 to follow tarball names
-    # folder_name = 'binutils-' + '.'.join(str(x) for x in LATEST_BINUTILS_RELEASE if x)
-    # This logic does not hold for the 2.46 tarball unfortunately:
-    # https://inbox.sourceware.org/binutils/b30e780b-abc4-437b-bdcf-bb743a1c9eea@redhat.com/
-    folder_name = 'binutils-' + '.'.join(map(str, LATEST_BINUTILS_RELEASE))
+    folder_name = 'binutils-' + '.'.join(str(x) for x in LATEST_BINUTILS_RELEASE if x)
 
     bsm.location = Path(tc_build_folder, 'src', folder_name)
     bsm.tarball.base_download_url = 'https://sourceware.org/pub/binutils/releases'


### PR DESCRIPTION
This also reverts the 2.46 workaround logic, in anticipation that the 2.47 release will mirror all other releases.
