### PR TITLE
tc_build: llvm: Use '-Wno-author' instead of '-Wno-dev' with cmake 4.4+

### DIFF
--- a/tc_build/llvm.py
+++ b/tc_build/llvm.py
@@ -345,13 +345,21 @@ class LLVMBuilder(Builder):
         self.validate_targets()
         self.set_llvm_major_version()
 
+        cmake_version_str = subprocess.run(
+            ['cmake', '--version'], capture_output=True, check=True, text=True
+        ).stdout.splitlines()[0]
+        if not (match := re.search(r"cmake version ([0-9.]+)", cmake_version_str)):
+            msg = f"Could not parse 'cmake --version' ('{cmake_version_str}')?"
+            raise RuntimeError(msg)
+        cmake_version = tuple(int(x) for x in match.groups()[0].split('.'))
+
         # fmt: off
         cmake_cmd = [
             'cmake',
             '-B', self.folders.build,
             '-G', 'Ninja',
             '-S', Path(self.folders.source, 'llvm'),
-            '-Wno-dev',
+            '-Wno-author' if cmake_version >= (4, 4, 0) else '-Wno-dev',
         ]
         # fmt: on
         if self.quiet_cmake:


### PR DESCRIPTION
`-Wno-dev` has been deprecated in favor of `-Wno-author` in `cmake` 4.4: https://cmake.org/cmake/help/latest/release/4.4.html#deprecated-and-removed-features
