### PR TITLE
tc_build: source: Only fetch the requested ref when cloning shallow

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -448,8 +448,8 @@ clone_options.add_argument(
 
                     1. This cannot be used with '--use-good-revision'.
 
-                    2. When no '--branch' is specified, only main is fetched. To work with other branches,
-                       a branch other than main needs to be specified when the repo is first cloned.
+                    2. Only the ref specified by '--ref' (main by default) is fetched. To work with a
+                       different ref, the repo has to be cloned again with that ref.
 
                            '''),
     action='store_true',

--- a/tc_build/source.py
+++ b/tc_build/source.py
@@ -112,7 +112,7 @@ class GitSourceManager:
         if shallow:
             git_clone.append('--depth=1')
             if ref != 'main':
-                git_clone.append('--no-single-branch')
+                git_clone.append(f"--branch={ref}")
         git_clone += [self._repo_url, self.repo]
 
         subprocess.run(git_clone, check=True)


### PR DESCRIPTION
'--shallow-clone' with a ref other than main adds '--no-single-branch' to work around '--depth=1' implying '--single-branch', so that the checkout after the clone succeeds. That fetches the tip of every ref, which is thousands of them for llvm-project, making a shallow clone nearly as slow as a full one.

Use '--branch' instead, which fetches only the requested ref and works for both branches and tags. Hashes were already unsupported here, so nothing is lost.