### PR TITLE
build-llvm.py: Deduplicate '--targets'

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -588,7 +588,7 @@ def_llvm_builder_cls = LLVMBuilder if args.full_toolchain else LLVMSlimBuilder
 final = def_llvm_builder_cls()
 final.folders.source = llvm_folder
 if args.targets:
-    final.targets = args.targets
+    final.targets = sorted(set(args.targets))
     final.validate_targets()
 else:
     final.targets = ['all'] if args.full_toolchain else llvm_source.default_targets()


### PR DESCRIPTION
A user may pass a list of targets that includes a backend twice, like when creating a host target architecture agnostic reproducer that includes the host targets backend.

```
-t AArch64 ARM $(get_host_llvm_target)
```

on an `aarch64` machine would expand to

```
-t AArch64 ARM AArch64
```

which will then be passed to `cmake` as

```
-DLLVM_TARGETS_TO_BUILD=AArch64;ARM;AArch64
```

While there is no real issue from this, deduplicate and sort the targets when passed in to avoid unnecessarily dealing with the same values more than once in the script's internal checks.
