### PR TITLE
Bump PGO kernel to 7.2 and bump known good revision

### DIFF
--- a/build-llvm.py
+++ b/build-llvm.py
@@ -36,7 +36,7 @@ except ImportError:
 GOOD_REVISION = '51d823197cb40a57f25d00882546374d460c649e'
 
 # The version of the Linux kernel that the script downloads if necessary
-DEFAULT_KERNEL_FOR_PGO = (7, 1, 0)
+DEFAULT_KERNEL_FOR_PGO = (7, 2, 0)
 
 parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
 clone_options = parser.add_mutually_exclusive_group()

--- a/build-llvm.py
+++ b/build-llvm.py
@@ -33,7 +33,7 @@ except ImportError:
     BOOL_ARGS = {'action': 'store_true'}
 
 # This is a known good revision of LLVM for building the kernel
-GOOD_REVISION = '51d823197cb40a57f25d00882546374d460c649e'
+GOOD_REVISION = 'c31c334e11186d2c0b6a68a9f5619a4050cb87b7'
 
 # The version of the Linux kernel that the script downloads if necessary
 DEFAULT_KERNEL_FOR_PGO = (7, 2, 0)


### PR DESCRIPTION
This has been lightly qualified on an aarch64 and x86_64 host with the environment and configuration that I build the kernel.org toolchains with.
